### PR TITLE
Bump version to 0.3.6 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "simple-coding-time-tracker",
   "displayName": "Simple Coding Time Tracker",
   "description": "Track and visualize your coding time across projects",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "publisher": "noorashuvo",
   "license": "MIT",
   "icon": "icon-sctt.png",


### PR DESCRIPTION
This pull request includes a version bump in the `package.json` file to prepare for a new release.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the version from `0.3.5` to `0.3.6` to reflect the upcoming release.