### PR TITLE
add repository statistics workflow for automated metrics collection

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -1,0 +1,29 @@
+name: Repository Statistics
+run-name: 📊 Collect Repository Metrics
+
+on:
+  schedule:
+    # Runs every 2nd day at 02:00 UTC (less busy time)
+    - cron: '0 2 */2 * *'
+  workflow_dispatch:  # Allow manual trigger for testing
+
+permissions:
+  contents: write    # Needed to write stats data
+  pull-requests: read
+  issues: read
+
+jobs:
+  repo-stats:
+    name: Generate Repository Statistics
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Generate repository statistics
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          repository: ${{ github.repository }}
+          ghtoken: ${{ secrets.REPO_STATS_TOKEN }}  # Use custom PAT instead
+          databranch: stats-data


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to generate repository statistics. The workflow is scheduled to run every two days and includes permissions and steps for collecting and storing metrics.

### New GitHub Actions workflow:

* [`.github/workflows/repo-stats.yml`](diffhunk://#diff-1eac10076b4cb4c7d47994aaca111aa4bd1922b534ec01d451bd4ebceb86484dR1-R29): Added a workflow named "Repository Statistics" that runs every two days at 02:00 UTC and can also be triggered manually. It uses the `github-repo-stats` action to generate repository metrics and stores them in a specified data branch.