### PR TITLE
Feature/start of week

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ You can customize the extension's behavior through VS Code settings:
      - Default: 180 seconds (3 minutes)
      - Determines how long to keep tracking when you switch to other applications
      - Useful for when you're referencing documentation or testing your application
+   - **Week Start Day**: The first day of the week
+     - Default: Sunday
+     - Determines the first day of the week  
 
 
 ## Screenshots

--- a/package.json
+++ b/package.json
@@ -34,6 +34,20 @@
           "type": "number",
           "default": 180,
           "description": "If you switch away from VS Code, continue counting as coding time for up to this many seconds before pausing."
+        },
+        "simpleCodingTimeTracker.weekStartDay": {
+          "type": "string",
+          "default": "Sunday",
+          "enum": [
+            "Sunday",
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday"
+          ],
+          "description": "Day of the week to start the week."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
             "Friday",
             "Saturday"
           ],
-          "description": "Day of the week to start the week."
+          "description": "The first day of a week."
         }
       }
     },

--- a/src/summaryView.ts
+++ b/src/summaryView.ts
@@ -68,6 +68,10 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
             allTime: formatTime(await this.timeTracker.getAllTimeTotal())
         };
 
+        const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
+        const weekStartDay = config.get<string>('weekStartDay', 'Sunday');
+        const configData = { weekStartDay };
+
         if (webview) {
             webview.html = this.getHtmlForWebview(projects);
             webview.postMessage({ 
@@ -75,12 +79,13 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                 data: summaryData, 
                 projects, 
                 branches,
-                totalTime 
+                totalTime,
+                configData // Pass the config data to the webview as well
             });
         } else if (this.panel) {
             this.panel.reveal();
             this.panel.webview.html = this.getHtmlForWebview(projects);
-            this.panel.webview.postMessage({ command: 'update', data: summaryData, projects: projects, totalTime: totalTime });
+            this.panel.webview.postMessage({ command: 'update', data: summaryData, projects, totalTime, configData });
         } else {
             this.panel = vscode.window.createWebviewPanel(
                 'codingTimeSummary',
@@ -114,7 +119,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                 this.panel = undefined;
             });
 
-            this.panel.webview.postMessage({ command: 'update', data: summaryData, projects, branches, totalTime });
+            this.panel.webview.postMessage({ command: 'update', data: summaryData, projects, branches, totalTime, configData });
         }
     }
 
@@ -421,7 +426,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                         <div class="total-time-item">
                             <h3>This Week</h3>
                             <p id="weekly-total">Loading...</p>
-                            <small>Sunday - today</small>
+                            <small id="week-start-day-label">Loading...</small>
                         </div>
                         <div class="total-time-item">
                             <h3>This Month</h3>
@@ -570,14 +575,15 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                         }
                     };
                     
-                    window.addEventListener('message', event => {                        const message = event.data;
+                    window.addEventListener('message', event => {
+                        const message = event.data;
                         if (message.command === 'update') {
                             updateContent(message.data);
                             updateProjectDropdown(message.projects);
                             if (message.branches) {
                                 updateBranchDropdown(message.branches);
                             }
-                            updateTotalTimeSection(message.totalTime);
+                            updateTotalTimeSection(message.totalTime, message.configData);
                         } else if (message.command === 'searchResult') {
                             displaySearchResult(message.data);
                         } else if (message.command === 'updateBranches') {
@@ -639,13 +645,21 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                         }
                     }
 
-                    function updateTotalTimeSection(totalTime) {
+                    function updateTotalTimeSection(totalTime, configData) {
                         document.getElementById('today-total').textContent = totalTime.today;
                         document.getElementById('weekly-total').textContent = totalTime.weekly;
                         document.getElementById('monthly-total').textContent = totalTime.monthly;
                         document.getElementById('yearly-total').textContent = totalTime.yearly;
                         document.getElementById('all-time-total').textContent = totalTime.allTime;
-
+                        
+                        // Set the week range label if you add an element for it
+                        if (configData && configData.weekStartDay) {
+                            const weekStartDayLabel = document.getElementById('week-start-day-label');
+                            if (weekStartDayLabel) {
+                                weekStartDayLabel.textContent = configData.weekStartDay + ' - today';
+                            }
+                        }
+                        
                         // Set the start of the current month
                         const now = new Date();
                         const monthNames = ["January", "February", "March", "April", "May", "June",

--- a/src/timeTracker.ts
+++ b/src/timeTracker.ts
@@ -23,6 +23,17 @@ export class TimeTracker implements vscode.Disposable {
     private focusTimeoutSeconds: number = 60;
     private gitWatcher: GitWatcher | null = null;
     private branchCheckInterval: NodeJS.Timeout | null = null;
+    private weekStartDay: number = 0; // 0 = Sunday by default
+
+    private static readonly WEEKDAY_MAP: Record<string, number> = {
+        Sunday: 0,
+        Monday: 1,
+        Tuesday: 2,
+        Wednesday: 3,
+        Thursday: 4,
+        Friday: 5,
+        Saturday: 6
+    };
 
     constructor(database: Database) {
         this.database = database;
@@ -99,6 +110,10 @@ export class TimeTracker implements vscode.Disposable {
         this.saveIntervalSeconds = config.get('saveInterval', 5);
         this.inactivityTimeoutSeconds = config.get('inactivityTimeout', 300);
         this.focusTimeoutSeconds = config.get('focusTimeout', 60);
+
+        // Map string to number for weekStartDay
+        const weekStartDayStr = config.get<string>('weekStartDay', 'Sunday');
+        this.weekStartDay = TimeTracker.WEEKDAY_MAP[weekStartDayStr] ?? 0; 
     }
 
     private async updateCurrentBranch() {
@@ -294,7 +309,10 @@ export class TimeTracker implements vscode.Disposable {
 
     async getWeeklyTotal(): Promise<number> {
         const now = new Date();
-        const startOfWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() - now.getDay());
+        // Calculate difference between current day and weekStartDay
+        let diff = now.getDay() - this.weekStartDay;
+        if (diff < 0) diff += 7;
+        const startOfWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() - diff);
         return this.getTotalSince(startOfWeek);
     }
 


### PR DESCRIPTION
This pull request adds a configuration option to select what day should be considered as the first day of the week. Currently, the week starts from Sunday, however, in many countries week starts from Monday. To make it flexible, the user can select any day as of now, which is Sunday by default.