### PR TITLE
refactor: update health notification settings and improve time tracki…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "simpleCodingTimeTracker.health.eyeRestInterval": 20,
     "simpleCodingTimeTracker.health.stretchInterval": 100,
-    "simpleCodingTimeTracker.inactivityTimeout": 15000,
-    "simpleCodingTimeTracker.focusTimeout": 18000
+    "simpleCodingTimeTracker.inactivityTimeout": 2.5,
+    "simpleCodingTimeTracker.focusTimeout": 3
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,6 @@ To compile the extension, run:
 
 This will transpile the TypeScript files to JavaScript.
 
-## Testing
-
-To run the tests, use:
-`npm test`
-
-Make sure to write tests for any new functionality you add.
-
 ## Creating a VSCode Package
 
 To package the extension for distribution:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ Simple Coding Time Tracker is a powerful extension for Visual Studio Code that h
   - Quick Reset: One-click reset for search filters
 - **Data Persistence**: Safely stores your time data for long-term analysis.
 
-## Health Notification System
+## Time Tracking Details
+The extension tracks your coding time by monitoring file changes and user activity within Visual Studio Code. It uses a combination of timers and event listeners to ensure accurate tracking without impacting performance.
+
+**📖 For detailed configuration, advanced features, and complete documentation, see the [Time Tracking Guide](https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki/Time-Tracking) in our wiki.**
+
+## Health Notification System Details
 
 The extension includes a comprehensive health notification system to promote healthy coding habits and prevent strain-related issues.
 
@@ -68,12 +73,12 @@ You can customize the extension's behavior through VS Code settings:
 1. Open VS Code Settings (Ctrl+, or Cmd+, on macOS)
 2. Search for "Simple Coding Time Tracker"
 3. Available settings:  
-   - **Inactivity Timeout**: How long to wait before stopping the timer when no activity is detected but you are focused on VS Code (in seconds)
-     - Default: 150 seconds (2.5 minutes)
+   - **Inactivity Timeout**: How long to wait before stopping the timer when no activity is detected but you are focused on VS Code (in minutes)
+     - Default: 2.5 minutes
      - Lower values will stop tracking sooner when you're not actively coding
      - Higher values will continue tracking for longer during breaks
-   - **Focus Timeout**: How long to continue tracking after VS Code loses focus (in seconds)
-     - Default: 180 seconds (3 minutes)
+   - **Focus Timeout**: How long to continue tracking after VS Code loses focus (in minutes)
+     - Default: 3 minutes
      - Determines how long to keep tracking when you switch to other applications
      - Useful for when you're referencing documentation or testing your application
    - **Health Notifications**: Configure health reminder settings

--- a/package.json
+++ b/package.json
@@ -22,13 +22,17 @@
       "properties": {
         "simpleCodingTimeTracker.inactivityTimeout": {
           "type": "number",
-          "default": 150,
-          "description": "Pause tracking if there is no keyboard or mouse activity in VS Code for this many seconds."
+          "default": 2.5,
+          "minimum": 0.5,
+          "maximum": 60,
+          "description": "Pause tracking if there is no keyboard or mouse activity in VS Code for this many minutes."
         },
         "simpleCodingTimeTracker.focusTimeout": {
           "type": "number",
-          "default": 180,
-          "description": "If you switch away from VS Code, continue counting as coding time for up to this many seconds before pausing."
+          "default": 3,
+          "minimum": 0.5,
+          "maximum": 60,
+          "description": "If you switch away from VS Code, continue counting as coding time for up to this many minutes before pausing."
         },
         "simpleCodingTimeTracker.health.enableNotifications": {
           "type": "boolean",
@@ -43,16 +47,22 @@
         "simpleCodingTimeTracker.health.eyeRestInterval": {
           "type": "number",
           "default": 20,
+          "minimum": 5,
+          "maximum": 120,
           "description": "Interval for eye rest reminders (minutes) - Based on 20-20-20 rule"
         },
         "simpleCodingTimeTracker.health.stretchInterval": {
           "type": "number",
           "default": 30,
+          "minimum": 10,
+          "maximum": 180,
           "description": "Interval for stretch reminders (minutes) - Recommended for posture health"
         },
         "simpleCodingTimeTracker.health.breakThreshold": {
           "type": "number",
-          "default": 120,
+          "default": 90,
+          "minimum": 30,
+          "maximum": 480,
           "description": "Coding duration before suggesting a break (minutes) - Based on ultradian rhythms"
         }
       }

--- a/src/healthNotifications.ts
+++ b/src/healthNotifications.ts
@@ -27,8 +27,8 @@ export class HealthNotificationManager {
         const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
         this.settings = {
             eyeRestInterval: config.get('health.eyeRestInterval', 20),
-            stretchInterval: config.get('health.stretchInterval', 45),
-            breakThreshold: config.get('health.breakThreshold', 120),
+            stretchInterval: config.get('health.stretchInterval', 30),
+            breakThreshold: config.get('health.breakThreshold', 90),
             enableNotifications: config.get('health.enableNotifications', true),
             modalNotifications: config.get('health.modalNotifications', true)
         };
@@ -204,7 +204,7 @@ export class HealthNotificationManager {
         }
 
         const result = await vscode.window.showErrorMessage(
-            '🚨 HEALTH BREAK REQUIRED: You\'ve been coding for 2+ hours! Take a break now for your health.',
+            '🚨 HEALTH BREAK REQUIRED: You\'ve been coding intensely! Take a break now for your health.',
             { modal: this.settings.modalNotifications },
             doneAction,
             remindAction

--- a/src/healthNotifications.ts.md
+++ b/src/healthNotifications.ts.md
@@ -111,8 +111,8 @@ All notifications are designed to be **persistent** rather than auto-dismissing:
 The system uses three independent timers:
 
 1. **Eye Rest Timer**: Triggers every 20 minutes (configurable)
-2. **Stretch Timer**: Triggers every 45 minutes (configurable)  
-3. **Break Timer**: Triggers every 120 minutes (configurable)
+2. **Stretch Timer**: Triggers every 30 minutes (configurable)  
+3. **Break Timer**: Triggers every 90 minutes (configurable)
 
 Each timer is implemented using `setTimeout` with automatic restart:
 

--- a/src/timeTracker.ts
+++ b/src/timeTracker.ts
@@ -22,9 +22,9 @@ export class TimeTracker implements vscode.Disposable {
     private saveIntervalSeconds: number = 5;
     private lastCursorActivity: number = Date.now();
     private cursorInactivityTimeout: NodeJS.Timeout | null = null;
-    private inactivityTimeoutSeconds: number = 180;
+    private inactivityTimeoutSeconds: number = 150; // Default 2.5 minutes * 60 = 150 seconds
     private focusTimeoutHandle: NodeJS.Timeout | null = null;
-    private focusTimeoutSeconds: number = 180;
+    private focusTimeoutSeconds: number = 180; // Default 3 minutes * 60 = 180 seconds
     private gitWatcher: GitWatcher | null = null;
     private branchCheckInterval: NodeJS.Timeout | null = null;
     private isCheckingBranch: boolean = false;
@@ -124,8 +124,9 @@ export class TimeTracker implements vscode.Disposable {
     public updateConfiguration() {
         const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
         // this.saveIntervalSeconds = config.get('saveInterval', 5);
-        this.inactivityTimeoutSeconds = config.get('inactivityTimeout', 180);
-        this.focusTimeoutSeconds = config.get('focusTimeout', 180);
+        // Convert from minutes to seconds for internal use
+        this.inactivityTimeoutSeconds = config.get('inactivityTimeout', 2.5) * 60;
+        this.focusTimeoutSeconds = config.get('focusTimeout', 3) * 60;
         
         // Update health notification settings
         if (this.healthManager) {


### PR DESCRIPTION
This pull request updates the time tracking and health notification configuration for the Simple Coding Time Tracker extension, shifting key timeout settings from seconds to minutes for improved clarity and usability. It also refines default values and documentation to ensure consistency across the codebase, settings, and user guides.

**Time Tracking Configuration Updates:**

* Changed `inactivityTimeout` and `focusTimeout` settings from seconds to minutes in `package.json`, `.vscode/settings.json`, and internal logic. Updated their default values to 2.5 and 3 minutes, respectively, and added minimum/maximum limits for validation. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R35) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L4-R5) [[3]](diffhunk://#diff-f6e7703044cfd5d51e00edf946a4bb6419e1a6e1eec7368b041280bf6616e701L25-R27) [[4]](diffhunk://#diff-f6e7703044cfd5d51e00edf946a4bb6419e1a6e1eec7368b041280bf6616e701L127-R129)
* Updated documentation in `README.md` to reflect the new units (minutes) and defaults for timeouts, and linked to a detailed time tracking guide for advanced configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R81)

**Health Notification System Improvements:**

* Lowered default values for health reminders: stretch interval to 30 minutes and break threshold to 90 minutes in both code and documentation. Added validation ranges for these settings in `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R50-R65) [[2]](diffhunk://#diff-699ad48a04c268cc0e96d4a071bdff3348562a1845190920ff3ebeb7d442fce4L30-R31) [[3]](diffhunk://#diff-3171ba208ec301ccac20c9c0cf45863bddd81a1a6ed47f70b953636f42ce82f4L114-R115)
* Updated break notification message for clarity and accuracy.

**Documentation Cleanup:**

* Removed redundant test instructions from `CONTRIBUTING.md` to streamline contributor guidance.…ng intervals