### PR TITLE
fix: update health notifications default setting to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "simple-coding-time-tracker",
   "displayName": "Simple Coding Time Tracker",
   "description": "Track and visualize your coding time across projects",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "noorashuvo",
   "license": "MIT",
   "icon": "icon-sctt.png",
@@ -36,7 +36,7 @@
         },
         "simpleCodingTimeTracker.health.enableNotifications": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Enable health notifications during coding sessions"
         },
         "simpleCodingTimeTracker.health.modalNotifications": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Register health notifications toggle command (legacy command with confirmation)
     let toggleHealthCommand = vscode.commands.registerCommand('simpleCodingTimeTracker.toggleHealthNotifications', async () => {
         const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
-        const currentEnabled = config.get('health.enableNotifications', true);
+        const currentEnabled = config.get('health.enableNotifications', false);
         
         // Show current state and ask for confirmation
         const action = currentEnabled ? 'disable' : 'enable';

--- a/src/healthNotifications.ts
+++ b/src/healthNotifications.ts
@@ -29,7 +29,7 @@ export class HealthNotificationManager {
             eyeRestInterval: config.get('health.eyeRestInterval', 20),
             stretchInterval: config.get('health.stretchInterval', 30),
             breakThreshold: config.get('health.breakThreshold', 90),
-            enableNotifications: config.get('health.enableNotifications', true),
+            enableNotifications: config.get('health.enableNotifications', false),
             modalNotifications: config.get('health.modalNotifications', true)
         };
     }

--- a/src/notificationStatusBar.ts
+++ b/src/notificationStatusBar.ts
@@ -20,7 +20,7 @@ export class NotificationStatusBar implements vscode.Disposable {
 
     private updateStatusBar(): void {
         const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
-        const isEnabled = config.get('health.enableNotifications', true);
+        const isEnabled = config.get('health.enableNotifications', false);
         
         // Use minimal text with no extra spaces
         this.statusBarItem.text = isEnabled ? '🔔' : '🔕';
@@ -33,7 +33,7 @@ export class NotificationStatusBar implements vscode.Disposable {
 
     public async toggle(): Promise<void> {
         const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
-        const currentEnabled = config.get('health.enableNotifications', true);
+        const currentEnabled = config.get('health.enableNotifications', false);
         
         // Toggle the setting
         await config.update('health.enableNotifications', !currentEnabled, vscode.ConfigurationTarget.Global);

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -63,7 +63,7 @@ export class StatusBar implements vscode.Disposable {
         
         // Update notification status bar
         const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
-        const notificationsEnabled = config.get('health.enableNotifications', true);
+        const notificationsEnabled = config.get('health.enableNotifications', false);
         const notificationIcon = notificationsEnabled ? '🔔' : '🔕';
         this.notificationItem.text = notificationIcon;
         this.notificationItem.tooltip = `Health Notifications: ${notificationsEnabled ? 'ON' : 'OFF'} (Click to toggle)`;
@@ -84,7 +84,7 @@ export class StatusBar implements vscode.Disposable {
         const currentProject = this.timeTracker.getCurrentProject();
 
         const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
-        const notificationsEnabled = config.get('health.enableNotifications', true);
+        const notificationsEnabled = config.get('health.enableNotifications', false);
         const notificationStatus = notificationsEnabled ? 'ON' : 'OFF';
         
         return `${isActive ? 'Active' : 'Paused'} - Coding Time
@@ -102,7 +102,7 @@ Click to save session and show summary`;
     // Toggle notifications method
     private async toggleNotifications(): Promise<void> {
         const config = vscode.workspace.getConfiguration('simpleCodingTimeTracker');
-        const currentEnabled = config.get('health.enableNotifications', true);
+        const currentEnabled = config.get('health.enableNotifications', false);
         
         // Toggle the setting
         await config.update('health.enableNotifications', !currentEnabled, vscode.ConfigurationTarget.Global);


### PR DESCRIPTION
This pull request changes the default behavior for health notifications in the Simple Coding Time Tracker extension. Health notifications are now disabled by default, instead of enabled. This affects the default configuration, UI status indicators, and all logic that checks or toggles the notification setting.

**Default behavior update:**

* Changed the default value of `health.enableNotifications` to `false` in `package.json`, so new users will have notifications turned off by default.
* Updated all code references in `src/extension.ts`, `src/healthNotifications.ts`, `src/notificationStatusBar.ts`, and `src/statusBar.ts` to use `false` as the fallback/default value when reading `health.enableNotifications`. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L87-R87) [[2]](diffhunk://#diff-699ad48a04c268cc0e96d4a071bdff3348562a1845190920ff3ebeb7d442fce4L32-R32) [[3]](diffhunk://#diff-374f833c5512b1016de76be413db0c7b6aa1e0e66c6cd266c4accaf64f363c03L23-R23) [[4]](diffhunk://#diff-374f833c5512b1016de76be413db0c7b6aa1e0e66c6cd266c4accaf64f363c03L36-R36) [[5]](diffhunk://#diff-70fffed5d6495a255848861d8bda1121870d8813b9a8af3fb5333d5c99529b40L66-R66) [[6]](diffhunk://#diff-70fffed5d6495a255848861d8bda1121870d8813b9a8af3fb5333d5c99529b40L87-R87) [[7]](diffhunk://#diff-70fffed5d6495a255848861d8bda1121870d8813b9a8af3fb5333d5c99529b40L105-R105)

**Other:**

* Bumped extension version to `0.6.2` in `package.json`.