### PR TITLE
Add initial documentation and JavaScript for Simple Coding Time Track…

### DIFF
--- a/GITHUB_PAGES_SETUP.md
+++ b/GITHUB_PAGES_SETUP.md
@@ -1,0 +1,137 @@
+# 🚀 GitHub Pages Setup Guide
+
+## Quick Setup Steps
+
+Follow these steps to enable your GitHub Pages site:
+
+### 1. Push the docs folder to GitHub
+
+```bash
+git add docs/
+git commit -m "Add GitHub Pages site for extension demonstration"
+git push origin feature/extension-site
+```
+
+### 2. Merge to main branch (if needed)
+
+If you want the site live on main:
+```bash
+git checkout main
+git merge feature/extension-site
+git push origin main
+```
+
+### 3. Enable GitHub Pages
+
+1. Go to your repository: https://github.com/twentyTwo/vsc-ext-coding-time-tracker
+2. Click on **Settings** tab
+3. Scroll down to **Pages** in the left sidebar
+4. Under **Source**:
+   - Select **Deploy from a branch**
+   - Choose **main** branch
+   - Select **/docs** folder
+   - Click **Save**
+
+### 4. Wait for Deployment
+
+- GitHub will build and deploy your site (usually takes 1-2 minutes)
+- You'll see a message: "Your site is live at https://twentytwo.github.io/vsc-ext-coding-time-tracker/"
+- Click the link to view your live site!
+
+## 🎯 What You'll Get
+
+### Landing Page Features:
+✅ Beautiful hero section with gradient background  
+✅ Feature showcase with 9 key features  
+✅ Screenshot gallery (light/dark themes)  
+✅ Installation instructions  
+✅ Use cases section  
+✅ Responsive design (mobile, tablet, desktop)  
+✅ Smooth animations and transitions  
+✅ Links to VS Code Marketplace and Open VSX  
+
+### Documentation Page Features:
+✅ Complete user guide  
+✅ Configuration reference table  
+✅ Feature explanations  
+✅ Health notifications guide  
+✅ All available commands  
+✅ Troubleshooting section  
+✅ FAQ section  
+✅ Table of contents with smooth scrolling  
+
+## 🔗 Adding to Your Extension
+
+Once live, add the site URL to:
+
+1. **README.md** - Add a link to the live demo site
+2. **package.json** - Add to repository URL or homepage field
+3. **VS Code Marketplace** - Update extension description with site link
+
+## 📱 Testing Locally
+
+Before pushing, test locally:
+
+```bash
+cd docs
+python -m http.server 8000
+# Or use: npx http-server
+```
+
+Open: http://localhost:8000
+
+## 🎨 Customization Options
+
+### Colors (in css/style.css)
+```css
+:root {
+    --primary-color: #007acc;      /* VS Code blue */
+    --secondary-color: #68217a;     /* Purple accent */
+    --accent-color: #f9826c;        /* Coral accent */
+}
+```
+
+### Screenshots
+- Replace URLs in index.html with your own screenshot URLs
+- Current screenshots are pulled from your GitHub static hosting
+
+### Content
+- Edit text in index.html and documentation.html
+- Update links to match your repository
+
+## ⚡ Performance
+
+The site is optimized for:
+- Fast loading (no external dependencies)
+- Mobile-first responsive design
+- SEO-friendly semantic HTML
+- Accessible (ARIA labels, keyboard navigation)
+
+## 🐛 Troubleshooting
+
+**Site not showing up?**
+- Wait 2-5 minutes after enabling
+- Check Settings → Pages for build status
+- Ensure /docs folder exists on the branch
+- Hard refresh browser (Ctrl+Shift+R)
+
+**Images not loading?**
+- Verify image URLs are correct
+- Check if images are accessible publicly
+- Use relative paths for local images
+
+**Mobile menu not working?**
+- Clear browser cache
+- Check browser console for errors
+- Verify main.js is loading
+
+## 📞 Support
+
+Need help? Open an issue on GitHub!
+
+---
+
+**Your site will be live at:**  
+🌐 https://twentytwo.github.io/vsc-ext-coding-time-tracker/
+
+Enjoy your new extension showcase website! 🎉

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,105 @@
+# Simple Coding Time Tracker - GitHub Pages Site
+
+This directory contains the GitHub Pages website for the Simple Coding Time Tracker VS Code extension.
+
+## 🌐 Live Site
+
+The site is hosted at: `https://twentytwo.github.io/vsc-ext-coding-time-tracker/`
+
+## 📁 Structure
+
+```
+docs/
+├── index.html              # Main landing page
+├── documentation.html      # Complete documentation
+├── css/
+│   └── style.css          # Styles for all pages
+├── js/
+│   └── main.js            # Interactive features
+└── assets/                # Additional assets (if needed)
+```
+
+## 🚀 Features
+
+### Landing Page (`index.html`)
+- Hero section with call-to-action buttons
+- Feature showcase with interactive cards
+- Screenshot gallery with light/dark theme examples
+- Installation guide
+- Use cases section
+- Responsive design for all devices
+
+### Documentation Page (`documentation.html`)
+- Complete user guide
+- Configuration reference
+- Feature details
+- Health notifications guide
+- Command reference
+- Troubleshooting section
+- FAQ
+
+## 🎨 Design
+
+- **Responsive:** Works on desktop, tablet, and mobile
+- **Modern:** Clean, professional design with smooth animations
+- **Accessible:** Semantic HTML and proper ARIA labels
+- **Fast:** Optimized CSS and JavaScript
+- **Theme-aware:** Matches VS Code aesthetic
+
+## 🔧 Local Development
+
+To test the site locally:
+
+1. Open `index.html` in your browser, or
+2. Use a local server:
+   ```bash
+   # Python 3
+   python -m http.server 8000
+   
+   # Node.js (with http-server)
+   npx http-server
+   ```
+3. Navigate to `http://localhost:8000`
+
+## 📝 Updating Content
+
+### Adding Screenshots
+Place images in the root directory or `assets/` folder and update the `<img>` tags in `index.html`.
+
+### Modifying Styles
+Edit `css/style.css` to customize colors, fonts, layouts, etc.
+
+### Adding Interactivity
+Update `js/main.js` for new interactive features.
+
+## 🌍 GitHub Pages Setup
+
+To enable GitHub Pages:
+
+1. Go to your repository settings
+2. Navigate to "Pages" section
+3. Under "Source", select "Deploy from a branch"
+4. Choose the `main` branch and `/docs` folder
+5. Click "Save"
+6. Your site will be available at: `https://twentytwo.github.io/vsc-ext-coding-time-tracker/`
+
+## 📦 Technologies Used
+
+- Pure HTML5, CSS3, JavaScript (no frameworks)
+- Responsive Grid and Flexbox layouts
+- CSS animations and transitions
+- Intersection Observer API for scroll animations
+- Mobile-first responsive design
+
+## 🤝 Contributing
+
+To improve the website:
+
+1. Edit files in the `docs/` directory
+2. Test locally
+3. Commit and push changes
+4. Changes will be live within minutes
+
+## 📄 License
+
+This website and the extension are licensed under the MIT License.

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,0 +1,768 @@
+/* Root Variables */
+:root {
+    --primary-color: #007acc;
+    --primary-dark: #005a9e;
+    --secondary-color: #68217a;
+    --accent-color: #f9826c;
+    --text-dark: #1e1e1e;
+    --text-light: #ffffff;
+    --text-gray: #6e6e6e;
+    --bg-light: #ffffff;
+    --bg-gray: #f5f5f5;
+    --bg-dark: #1e1e1e;
+    --border-color: #e0e0e0;
+    --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.15);
+    --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Reset and Base Styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    line-height: 1.6;
+    color: var(--text-dark);
+    background-color: var(--bg-light);
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Navigation */
+.navbar {
+    background-color: var(--bg-light);
+    box-shadow: var(--shadow);
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    transition: var(--transition);
+}
+
+.nav-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 20px;
+}
+
+.logo {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+.logo-img {
+    width: 40px;
+    height: 40px;
+    border-radius: 8px;
+}
+
+.logo-text {
+    display: none;
+}
+
+.nav-links {
+    display: flex;
+    list-style: none;
+    gap: 2rem;
+    align-items: center;
+}
+
+.nav-links a {
+    color: var(--text-dark);
+    text-decoration: none;
+    font-weight: 500;
+    transition: var(--transition);
+    padding: 0.5rem 0;
+    border-bottom: 2px solid transparent;
+}
+
+.nav-links a:hover {
+    color: var(--primary-color);
+    border-bottom-color: var(--primary-color);
+}
+
+.github-link {
+    background-color: var(--text-dark);
+    color: var(--text-light) !important;
+    padding: 0.5rem 1rem !important;
+    border-radius: 6px;
+    border-bottom: none !important;
+}
+
+.github-link:hover {
+    background-color: var(--primary-color) !important;
+    transform: translateY(-2px);
+}
+
+.mobile-menu-toggle {
+    display: none;
+    flex-direction: column;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.5rem;
+}
+
+.mobile-menu-toggle span {
+    width: 25px;
+    height: 3px;
+    background-color: var(--text-dark);
+    margin: 3px 0;
+    transition: var(--transition);
+}
+
+/* Hero Section */
+.hero {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: var(--text-light);
+    padding: 100px 0 80px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: url('data:image/svg+xml,<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg"><defs><pattern id="grid" width="100" height="100" patternUnits="userSpaceOnUse"><path d="M 100 0 L 0 0 0 100" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="1"/></pattern></defs><rect width="100%" height="100%" fill="url(%23grid)"/></svg>');
+    opacity: 0.3;
+}
+
+.hero-content {
+    position: relative;
+    z-index: 1;
+}
+
+.hero-title {
+    font-size: 3.5rem;
+    font-weight: 800;
+    margin-bottom: 1.5rem;
+    line-height: 1.2;
+    animation: fadeInUp 0.8s ease-out;
+}
+
+.hero-subtitle {
+    font-size: 1.3rem;
+    max-width: 700px;
+    margin: 0 auto 2.5rem;
+    opacity: 0.95;
+    animation: fadeInUp 0.8s ease-out 0.2s both;
+}
+
+.hero-buttons {
+    display: flex;
+    gap: 1.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    animation: fadeInUp 0.8s ease-out 0.4s both;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 28px;
+    font-size: 1rem;
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: 8px;
+    transition: var(--transition);
+    cursor: pointer;
+    border: none;
+}
+
+.btn-primary {
+    background-color: var(--text-light);
+    color: var(--primary-color);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.btn-primary:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+}
+
+.btn-secondary {
+    background-color: rgba(255, 255, 255, 0.2);
+    color: var(--text-light);
+    border: 2px solid var(--text-light);
+}
+
+.btn-secondary:hover {
+    background-color: var(--text-light);
+    color: var(--primary-color);
+    transform: translateY(-3px);
+}
+
+.btn-large {
+    padding: 16px 32px;
+    font-size: 1.1rem;
+}
+
+.hero-stats {
+    display: flex;
+    justify-content: center;
+    gap: 4rem;
+    margin-top: 4rem;
+    animation: fadeInUp 0.8s ease-out 0.6s both;
+}
+
+.stat {
+    text-align: center;
+}
+
+.stat-number {
+    font-size: 2.5rem;
+    font-weight: 800;
+    margin-bottom: 0.5rem;
+}
+
+.stat-label {
+    font-size: 1rem;
+    opacity: 0.9;
+}
+
+/* Features Section */
+.features {
+    padding: 100px 0;
+    background-color: var(--bg-light);
+}
+
+.section-title {
+    text-align: center;
+    font-size: 2.8rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+    color: var(--text-dark);
+}
+
+.section-subtitle {
+    text-align: center;
+    font-size: 1.2rem;
+    color: var(--text-gray);
+    margin-bottom: 4rem;
+}
+
+.features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2.5rem;
+}
+
+.feature-card {
+    background: var(--bg-light);
+    padding: 2.5rem;
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+    border: 1px solid var(--border-color);
+}
+
+.feature-card:hover {
+    transform: translateY(-8px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--primary-color);
+}
+
+.feature-icon {
+    font-size: 3rem;
+    margin-bottom: 1.5rem;
+}
+
+.feature-card h3 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-dark);
+}
+
+.feature-card p {
+    color: var(--text-gray);
+    line-height: 1.7;
+}
+
+/* Screenshots Section */
+.screenshots {
+    padding: 100px 0;
+    background-color: var(--bg-gray);
+}
+
+.screenshot-showcase {
+    margin-top: 4rem;
+}
+
+.screenshot-item {
+    margin-bottom: 5rem;
+    text-align: center;
+}
+
+.screenshot-item h3 {
+    font-size: 1.8rem;
+    margin-bottom: 1.5rem;
+    color: var(--primary-color);
+}
+
+.screenshot-img {
+    width: 100%;
+    max-width: 1000px;
+    border-radius: 12px;
+    box-shadow: var(--shadow-lg);
+    margin-bottom: 1.5rem;
+    transition: var(--transition);
+}
+
+.screenshot-img:hover {
+    transform: scale(1.02);
+    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.2);
+}
+
+.screenshot-item p {
+    font-size: 1.1rem;
+    color: var(--text-gray);
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.screenshot-features {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 3rem;
+    margin-top: 4rem;
+}
+
+.screenshot-feature {
+    text-align: center;
+}
+
+.screenshot-feature h4 {
+    font-size: 1.3rem;
+    margin-bottom: 1rem;
+    color: var(--text-dark);
+}
+
+.screenshot-small {
+    max-width: 400px;
+    width: 100%;
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+    margin-bottom: 1rem;
+    transition: var(--transition);
+}
+
+.screenshot-small:hover {
+    transform: scale(1.05);
+}
+
+.screenshot-feature p {
+    color: var(--text-gray);
+    font-size: 1rem;
+}
+
+/* Installation Section */
+.installation {
+    padding: 100px 0;
+    background-color: var(--bg-light);
+}
+
+.installation-methods {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 3rem;
+    margin-top: 4rem;
+}
+
+.install-method {
+    background: var(--bg-gray);
+    padding: 3rem;
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+}
+
+.install-method h3 {
+    font-size: 1.8rem;
+    margin-bottom: 1.5rem;
+    color: var(--primary-color);
+}
+
+.install-description {
+    color: var(--text-gray);
+    font-style: italic;
+    margin-bottom: 1.5rem;
+}
+
+.install-method ol {
+    margin-left: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.install-method li {
+    margin-bottom: 1rem;
+    color: var(--text-gray);
+    line-height: 1.7;
+}
+
+.install-method code {
+    background-color: var(--bg-light);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-family: 'Courier New', monospace;
+    color: var(--secondary-color);
+}
+
+.quick-start {
+    margin-top: 5rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    padding: 4rem;
+    border-radius: 12px;
+    color: var(--text-light);
+}
+
+.quick-start h3 {
+    font-size: 2rem;
+    margin-bottom: 3rem;
+    text-align: center;
+}
+
+.quick-start-steps {
+    display: flex;
+    justify-content: space-between;
+    gap: 2rem;
+}
+
+.quick-step {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.step-number {
+    width: 60px;
+    height: 60px;
+    background-color: var(--text-light);
+    color: var(--primary-color);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.8rem;
+    font-weight: 800;
+    margin-bottom: 1.5rem;
+}
+
+.step-content h4 {
+    font-size: 1.3rem;
+    margin-bottom: 0.8rem;
+}
+
+.step-content p {
+    opacity: 0.95;
+}
+
+.step-content code {
+    background-color: rgba(255, 255, 255, 0.2);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-family: 'Courier New', monospace;
+}
+
+/* Use Cases Section */
+.use-cases {
+    padding: 100px 0;
+    background-color: var(--bg-gray);
+}
+
+.use-cases-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2.5rem;
+    margin-top: 4rem;
+}
+
+.use-case {
+    background: var(--bg-light);
+    padding: 2.5rem;
+    border-radius: 12px;
+    text-align: center;
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+}
+
+.use-case:hover {
+    transform: translateY(-5px);
+    box-shadow: var(--shadow-lg);
+}
+
+.use-case-icon {
+    font-size: 3.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.use-case h3 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-dark);
+}
+
+.use-case p {
+    color: var(--text-gray);
+}
+
+/* CTA Section */
+.cta {
+    padding: 100px 0;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: var(--text-light);
+    text-align: center;
+}
+
+.cta h2 {
+    font-size: 2.8rem;
+    font-weight: 800;
+    margin-bottom: 1.5rem;
+}
+
+.cta p {
+    font-size: 1.3rem;
+    margin-bottom: 3rem;
+    opacity: 0.95;
+}
+
+.cta-buttons {
+    display: flex;
+    gap: 1.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+/* Footer */
+.footer {
+    background-color: var(--bg-dark);
+    color: var(--text-light);
+    padding: 4rem 0 2rem;
+}
+
+.footer-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 3rem;
+    margin-bottom: 3rem;
+}
+
+.footer-section h4 {
+    font-size: 1.3rem;
+    margin-bottom: 1.5rem;
+    color: var(--text-light);
+}
+
+.footer-section p {
+    color: rgba(255, 255, 255, 0.7);
+    margin-bottom: 1.5rem;
+}
+
+.footer-links {
+    display: flex;
+    gap: 1.5rem;
+}
+
+.footer-links a,
+.footer-section a {
+    color: rgba(255, 255, 255, 0.7);
+    text-decoration: none;
+    transition: var(--transition);
+}
+
+.footer-links a:hover,
+.footer-section a:hover {
+    color: var(--primary-color);
+}
+
+.footer-section ul {
+    list-style: none;
+}
+
+.footer-section li {
+    margin-bottom: 0.8rem;
+}
+
+.footer-bottom {
+    text-align: center;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.6);
+}
+
+/* Animations */
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Responsive Design */
+@media (max-width: 1024px) {
+    .hero-title {
+        font-size: 2.8rem;
+    }
+
+    .hero-subtitle {
+        font-size: 1.1rem;
+    }
+
+    .hero-stats {
+        gap: 2rem;
+    }
+
+    .stat-number {
+        font-size: 2rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .logo-text {
+        display: inline;
+    }
+
+    .nav-links {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background-color: var(--bg-light);
+        flex-direction: column;
+        padding: 1rem;
+        box-shadow: var(--shadow);
+    }
+
+    .nav-links.active {
+        display: flex;
+    }
+
+    .mobile-menu-toggle {
+        display: flex;
+    }
+
+    .hero {
+        padding: 60px 0 40px;
+    }
+
+    .hero-title {
+        font-size: 2.2rem;
+    }
+
+    .hero-subtitle {
+        font-size: 1rem;
+    }
+
+    .hero-buttons {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .hero-stats {
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .features,
+    .screenshots,
+    .installation,
+    .use-cases,
+    .cta {
+        padding: 60px 0;
+    }
+
+    .section-title {
+        font-size: 2rem;
+    }
+
+    .features-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .installation-methods {
+        grid-template-columns: 1fr;
+    }
+
+    .quick-start {
+        padding: 2rem;
+    }
+
+    .quick-start-steps {
+        flex-direction: column;
+    }
+
+    .screenshot-features {
+        grid-template-columns: 1fr;
+    }
+
+    .use-cases-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .cta h2 {
+        font-size: 2rem;
+    }
+
+    .cta p {
+        font-size: 1.1rem;
+    }
+
+    .footer-content {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 480px) {
+    .logo-text {
+        font-size: 0.9rem;
+    }
+
+    .hero-title {
+        font-size: 1.8rem;
+    }
+
+    .hero-subtitle {
+        font-size: 0.95rem;
+    }
+
+    .btn {
+        padding: 12px 20px;
+        font-size: 0.9rem;
+    }
+
+    .section-title {
+        font-size: 1.8rem;
+    }
+
+    .feature-card {
+        padding: 1.5rem;
+    }
+}

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -1,0 +1,677 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Complete documentation for Simple Coding Time Tracker VS Code extension">
+    <title>Documentation - Simple Coding Time Tracker</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="icon" type="image/png" href="../icon-sctt.png">
+    <style>
+        .docs-container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 40px 20px 80px;
+        }
+
+        .docs-header {
+            text-align: center;
+            margin-bottom: 60px;
+            padding-top: 40px;
+        }
+
+        .docs-header h1 {
+            font-size: 3rem;
+            color: var(--primary-color);
+            margin-bottom: 1rem;
+        }
+
+        .docs-toc {
+            background: var(--bg-gray);
+            padding: 30px;
+            border-radius: 12px;
+            margin-bottom: 40px;
+            border-left: 4px solid var(--primary-color);
+        }
+
+        .docs-toc h2 {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+            color: var(--text-dark);
+        }
+
+        .docs-toc ul {
+            list-style: none;
+            padding-left: 0;
+        }
+
+        .docs-toc li {
+            margin-bottom: 0.8rem;
+        }
+
+        .docs-toc a {
+            color: var(--primary-color);
+            text-decoration: none;
+            font-weight: 500;
+            transition: var(--transition);
+            display: inline-block;
+        }
+
+        .docs-toc a:hover {
+            transform: translateX(5px);
+            text-decoration: underline;
+        }
+
+        .docs-section {
+            margin-bottom: 60px;
+            scroll-margin-top: 100px;
+        }
+
+        .docs-section h2 {
+            font-size: 2.2rem;
+            color: var(--text-dark);
+            margin-bottom: 1.5rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 3px solid var(--primary-color);
+        }
+
+        .docs-section h3 {
+            font-size: 1.6rem;
+            color: var(--primary-color);
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+        }
+
+        .docs-section h4 {
+            font-size: 1.3rem;
+            color: var(--text-dark);
+            margin-top: 1.5rem;
+            margin-bottom: 0.8rem;
+        }
+
+        .docs-section p {
+            color: var(--text-gray);
+            line-height: 1.8;
+            margin-bottom: 1.2rem;
+        }
+
+        .docs-section ul,
+        .docs-section ol {
+            margin-left: 2rem;
+            margin-bottom: 1.5rem;
+            color: var(--text-gray);
+            line-height: 1.8;
+        }
+
+        .docs-section li {
+            margin-bottom: 0.8rem;
+        }
+
+        .code-block {
+            background: var(--bg-dark);
+            color: #f8f8f2;
+            padding: 20px;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin: 1.5rem 0;
+            font-family: 'Courier New', monospace;
+            font-size: 0.9rem;
+        }
+
+        .inline-code {
+            background: var(--bg-gray);
+            color: var(--secondary-color);
+            padding: 3px 8px;
+            border-radius: 4px;
+            font-family: 'Courier New', monospace;
+            font-size: 0.9em;
+        }
+
+        .info-box {
+            background: #e3f2fd;
+            border-left: 4px solid #2196f3;
+            padding: 20px;
+            margin: 1.5rem 0;
+            border-radius: 4px;
+        }
+
+        .info-box.warning {
+            background: #fff3e0;
+            border-left-color: #ff9800;
+        }
+
+        .info-box.success {
+            background: #e8f5e9;
+            border-left-color: #4caf50;
+        }
+
+        .info-box h4 {
+            margin-top: 0;
+            color: var(--text-dark);
+        }
+
+        .info-box p:last-child {
+            margin-bottom: 0;
+        }
+
+        .config-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+            background: var(--bg-light);
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: var(--shadow);
+        }
+
+        .config-table th {
+            background: var(--primary-color);
+            color: var(--text-light);
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
+
+        .config-table td {
+            padding: 15px;
+            border-bottom: 1px solid var(--border-color);
+            color: var(--text-gray);
+        }
+
+        .config-table tr:last-child td {
+            border-bottom: none;
+        }
+
+        .config-table tr:hover {
+            background: var(--bg-gray);
+        }
+
+        .back-to-home {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            color: var(--primary-color);
+            text-decoration: none;
+            font-weight: 600;
+            margin-bottom: 30px;
+            transition: var(--transition);
+        }
+
+        .back-to-home:hover {
+            transform: translateX(-5px);
+        }
+
+        @media (max-width: 768px) {
+            .docs-header h1 {
+                font-size: 2rem;
+            }
+
+            .docs-section h2 {
+                font-size: 1.8rem;
+            }
+
+            .config-table {
+                font-size: 0.85rem;
+            }
+
+            .config-table th,
+            .config-table td {
+                padding: 10px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar">
+        <div class="container nav-container">
+            <div class="logo">
+                <img src="../icon-sctt.png" alt="SCTT Logo" class="logo-img">
+                <span class="logo-text">Simple Coding Time Tracker</span>
+            </div>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="index.html#features">Features</a></li>
+                <li><a href="index.html#installation">Installation</a></li>
+                <li><a href="documentation.html">Documentation</a></li>
+                <li><a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker" class="github-link" target="_blank">GitHub</a></li>
+            </ul>
+            <button class="mobile-menu-toggle" aria-label="Toggle mobile menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>
+
+    <div class="docs-container">
+        <div class="docs-header">
+            <a href="index.html" class="back-to-home">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+                </svg>
+                Back to Home
+            </a>
+            <h1>Documentation</h1>
+            <p>Complete guide to using Simple Coding Time Tracker</p>
+        </div>
+
+        <!-- Table of Contents -->
+        <div class="docs-toc">
+            <h2>📑 Table of Contents</h2>
+            <ul>
+                <li><a href="#overview">Overview</a></li>
+                <li><a href="#getting-started">Getting Started</a></li>
+                <li><a href="#configuration">Configuration Settings</a></li>
+                <li><a href="#features-detail">Feature Details</a></li>
+                <li><a href="#health-notifications">Health Notifications</a></li>
+                <li><a href="#commands">Available Commands</a></li>
+                <li><a href="#data-management">Data Management</a></li>
+                <li><a href="#troubleshooting">Troubleshooting</a></li>
+                <li><a href="#faq">Frequently Asked Questions</a></li>
+            </ul>
+        </div>
+
+        <!-- Overview Section -->
+        <section id="overview" class="docs-section">
+            <h2>📖 Overview</h2>
+            <p>Simple Coding Time Tracker is a powerful VS Code extension that automatically tracks your coding time across projects, Git branches, and programming languages. It provides detailed insights into your coding habits with beautiful visualizations and comprehensive statistics.</p>
+            
+            <h3>Key Features</h3>
+            <ul>
+                <li><strong>Automatic Time Tracking:</strong> Seamlessly tracks coding time in the background</li>
+                <li><strong>Git Branch Tracking:</strong> Monitors time spent on different branches</li>
+                <li><strong>Language Detection:</strong> Tracks 50+ programming languages automatically</li>
+                <li><strong>Smart Activity Detection:</strong> Pauses during inactivity periods</li>
+                <li><strong>Interactive Visualizations:</strong> Charts for projects, daily activity, heatmaps, and languages</li>
+                <li><strong>Health Notifications:</strong> Scientific reminders for eye rest, stretching, and breaks</li>
+                <li><strong>Theme-Aware Design:</strong> Adapts to VS Code's light and dark themes</li>
+            </ul>
+        </section>
+
+        <!-- Getting Started -->
+        <section id="getting-started" class="docs-section">
+            <h2>🚀 Getting Started</h2>
+            
+            <h3>Installation</h3>
+            <ol>
+                <li>Open Visual Studio Code</li>
+                <li>Go to Extensions view (<code class="inline-code">Ctrl+Shift+X</code> or <code class="inline-code">Cmd+Shift+X</code> on macOS)</li>
+                <li>Search for "Simple Coding Time Tracker"</li>
+                <li>Click "Install"</li>
+            </ol>
+
+            <div class="info-box success">
+                <h4>✅ Installation Complete!</h4>
+                <p>The extension will automatically start tracking when you begin coding. Check the status bar at the bottom of VS Code to see your today's coding time.</p>
+            </div>
+
+            <h3>First Use</h3>
+            <p>Once installed, the extension works automatically:</p>
+            <ol>
+                <li>Open a project in VS Code</li>
+                <li>Start coding - tracking begins automatically</li>
+                <li>View your stats by clicking the status bar or running <code class="inline-code">SCTT: Show Coding Time Summary</code></li>
+            </ol>
+        </section>
+
+        <!-- Configuration -->
+        <section id="configuration" class="docs-section">
+            <h2>⚙️ Configuration Settings</h2>
+            <p>Access settings via VS Code Settings (<code class="inline-code">Ctrl+,</code>) or use the dedicated Settings View by clicking "Settings" in the summary view.</p>
+
+            <table class="config-table">
+                <thead>
+                    <tr>
+                        <th>Setting</th>
+                        <th>Description</th>
+                        <th>Default</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code class="inline-code">inactivityTimeout</code></td>
+                        <td>Minutes of inactivity before pausing tracking</td>
+                        <td>2.5 minutes</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">focusTimeout</code></td>
+                        <td>Continue tracking after VS Code loses focus (minutes)</td>
+                        <td>3 minutes</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">health.enableNotifications</code></td>
+                        <td>Enable/disable health notifications</td>
+                        <td>false</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">health.modalNotifications</code></td>
+                        <td>Make health notifications modal (blocks UI)</td>
+                        <td>true</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">health.eyeRestInterval</code></td>
+                        <td>Eye rest reminder frequency (minutes)</td>
+                        <td>20 minutes</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">health.stretchInterval</code></td>
+                        <td>Stretch reminder frequency (minutes)</td>
+                        <td>30 minutes</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">health.breakThreshold</code></td>
+                        <td>Break suggestion after continuous coding (minutes)</td>
+                        <td>90 minutes</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>Recommended Settings</h3>
+            <div class="info-box">
+                <h4>💡 Productivity Tips</h4>
+                <ul>
+                    <li><strong>Inactivity Timeout:</strong> Set to 2-3 minutes for accurate tracking without gaps</li>
+                    <li><strong>Focus Timeout:</strong> Set to 3-5 minutes if you frequently switch to browsers or documentation</li>
+                    <li><strong>Health Notifications:</strong> Enable for better coding health and productivity</li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Features Detail -->
+        <section id="features-detail" class="docs-section">
+            <h2>🎯 Feature Details</h2>
+
+            <h3>Automatic Time Tracking</h3>
+            <p>The extension tracks time based on:</p>
+            <ul>
+                <li><strong>Keyboard Activity:</strong> Typing in the editor</li>
+                <li><strong>Mouse Activity:</strong> Cursor movements and selections</li>
+                <li><strong>File Changes:</strong> Opening, closing, or switching files</li>
+                <li><strong>Window Focus:</strong> VS Code being the active window</li>
+            </ul>
+
+            <h3>Git Branch Tracking</h3>
+            <p>Automatically monitors your current Git branch and associates coding time with it. When you switch branches, the extension:</p>
+            <ol>
+                <li>Saves the current session with the old branch</li>
+                <li>Starts a new session for the new branch</li>
+                <li>Maintains separate statistics for each branch</li>
+            </ol>
+
+            <h3>Language Detection</h3>
+            <p>Supports 50+ programming languages including:</p>
+            <ul>
+                <li>JavaScript, TypeScript, Python, Java, C++, C#</li>
+                <li>Go, Rust, PHP, Ruby, Swift, Kotlin</li>
+                <li>HTML, CSS, SCSS, JSON, YAML, Markdown</li>
+                <li>SQL, Bash, and many more</li>
+            </ul>
+
+            <h3>Interactive Visualizations</h3>
+            <h4>Project Summary Chart</h4>
+            <p>Displays time distribution across different projects with interactive tooltips showing exact durations.</p>
+
+            <h4>Daily Activity Timeline</h4>
+            <p>Line chart showing your coding patterns over time, helping identify your most productive hours.</p>
+
+            <h4>Activity Heatmap</h4>
+            <p>3-month calendar view showing coding intensity, similar to GitHub contribution graphs.</p>
+
+            <h4>Language Distribution</h4>
+            <p>Pie chart showing time spent in different programming languages.</p>
+
+            <h3>Advanced Filtering</h3>
+            <p>Filter your data by:</p>
+            <ul>
+                <li><strong>Date Range:</strong> View data for specific time periods</li>
+                <li><strong>Project:</strong> Focus on specific projects</li>
+                <li><strong>Branch:</strong> Analyze time spent on different branches</li>
+                <li><strong>Language:</strong> See time distribution by programming language</li>
+            </ul>
+        </section>
+
+        <!-- Health Notifications -->
+        <section id="health-notifications" class="docs-section">
+            <h2>💪 Health Notifications</h2>
+            <p>The health notification system promotes healthy coding habits based on scientific research:</p>
+
+            <h3>Eye Rest Reminders (20-20-20 Rule)</h3>
+            <p><strong>Default: Every 20 minutes</strong></p>
+            <p>Reminds you to look at something 20 feet away for 20 seconds. This scientifically-proven technique helps prevent eye strain and digital eye fatigue.</p>
+
+            <div class="info-box">
+                <h4>👁️ Why It Matters</h4>
+                <p>Prolonged screen time can cause Computer Vision Syndrome (CVS). The 20-20-20 rule gives your eye muscles a chance to relax and reduces strain.</p>
+            </div>
+
+            <h3>Stretch Reminders</h3>
+            <p><strong>Default: Every 30 minutes</strong></p>
+            <p>Prompts you to stand up and stretch your back and neck. Regular stretching prevents muscle tension and improves posture.</p>
+
+            <h3>Break Suggestions (Ultradian Rhythms)</h3>
+            <p><strong>Default: Every 90 minutes</strong></p>
+            <p>Based on the body's natural 90-minute ultradian rhythm cycles. Taking breaks at these intervals maximizes focus and prevents burnout.</p>
+
+            <h3>Notification Actions</h3>
+            <p>Each health notification offers two options:</p>
+            <ul>
+                <li><strong>"I just did it!":</strong> Confirms you've completed the health action</li>
+                <li><strong>"Remind me later":</strong> Snoozes the notification for a shorter period</li>
+            </ul>
+
+            <h3>Modal vs. Non-Modal</h3>
+            <p>By default, health notifications are modal (they block the UI until dismissed). This ensures you actually take a break. You can disable this in settings if you prefer non-blocking notifications.</p>
+        </section>
+
+        <!-- Commands -->
+        <section id="commands" class="docs-section">
+            <h2>⌨️ Available Commands</h2>
+            <p>Access commands via Command Palette (<code class="inline-code">Ctrl+Shift+P</code> or <code class="inline-code">Cmd+Shift+P</code> on macOS):</p>
+
+            <table class="config-table">
+                <thead>
+                    <tr>
+                        <th>Command</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code class="inline-code">SCTT: Show Coding Time Summary</code></td>
+                        <td>Opens the main summary view with charts and statistics</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">SCTT: Open Settings</code></td>
+                        <td>Opens the dedicated settings view</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">SCTT: Toggle Health Notifications</code></td>
+                        <td>Quickly enable/disable health notifications</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">SCTT: View Time Tracking Data</code></td>
+                        <td>Exports raw tracking data as JSON</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">SCTT: Clear All Time Tracking Data</code></td>
+                        <td>Deletes all tracking data (with confirmation)</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">SCTT: Generate Test Data (Dev)</code></td>
+                        <td>Creates test data for 90 days (development only)</td>
+                    </tr>
+                    <tr>
+                        <td><code class="inline-code">SCTT: Delete Test Data (Dev)</code></td>
+                        <td>Removes all test data (development only)</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="info-box warning">
+                <h4>⚠️ Development Commands</h4>
+                <p>Test data commands are hidden by default. Enable <code class="inline-code">enableDevCommands</code> in settings to access them. These are intended for testing and development purposes only.</p>
+            </div>
+        </section>
+
+        <!-- Data Management -->
+        <section id="data-management" class="docs-section">
+            <h2>💾 Data Management</h2>
+
+            <h3>Data Storage</h3>
+            <p>All tracking data is stored locally in VS Code's storage. Your data never leaves your machine.</p>
+
+            <h3>Exporting Data</h3>
+            <p>Use <code class="inline-code">SCTT: View Time Tracking Data</code> to export your data as JSON format. This includes:</p>
+            <ul>
+                <li>Date of each coding session</li>
+                <li>Project name</li>
+                <li>Git branch</li>
+                <li>Programming language</li>
+                <li>Time spent (in minutes)</li>
+            </ul>
+
+            <h3>Clearing Data</h3>
+            <p>To delete all tracking data:</p>
+            <ol>
+                <li>Run <code class="inline-code">SCTT: Clear All Time Tracking Data</code></li>
+                <li>Confirm the action in the dialog</li>
+                <li>All data will be permanently deleted</li>
+            </ol>
+
+            <div class="info-box warning">
+                <h4>⚠️ Warning</h4>
+                <p>Clearing data is permanent and cannot be undone. Export your data first if you want to keep a backup.</p>
+            </div>
+
+            <h3>Data Privacy</h3>
+            <ul>
+                <li>All data is stored locally on your machine</li>
+                <li>No data is sent to external servers</li>
+                <li>No analytics or telemetry is collected</li>
+                <li>You have full control over your data</li>
+            </ul>
+        </section>
+
+        <!-- Troubleshooting -->
+        <section id="troubleshooting" class="docs-section">
+            <h2>🔧 Troubleshooting</h2>
+
+            <h3>Extension Not Tracking Time</h3>
+            <p><strong>Solution:</strong></p>
+            <ul>
+                <li>Check if VS Code window is focused</li>
+                <li>Ensure you're actively editing files</li>
+                <li>Verify extension is enabled in Extensions view</li>
+                <li>Reload VS Code window (<code class="inline-code">Ctrl+R</code> or <code class="inline-code">Cmd+R</code>)</li>
+            </ul>
+
+            <h3>Status Bar Not Showing</h3>
+            <p><strong>Solution:</strong></p>
+            <ul>
+                <li>Check if status bar is visible (View → Appearance → Status Bar)</li>
+                <li>Look for the clock icon on the right side of the status bar</li>
+                <li>Reload VS Code if necessary</li>
+            </ul>
+
+            <h3>Git Branch Not Detected</h3>
+            <p><strong>Solution:</strong></p>
+            <ul>
+                <li>Ensure your project is a Git repository</li>
+                <li>Check if Git is installed and accessible from command line</li>
+                <li>Verify you're on a valid branch (<code class="inline-code">git branch</code>)</li>
+            </ul>
+
+            <h3>Health Notifications Not Appearing</h3>
+            <p><strong>Solution:</strong></p>
+            <ul>
+                <li>Verify <code class="inline-code">health.enableNotifications</code> is set to <code class="inline-code">true</code></li>
+                <li>Ensure you've been coding for longer than the interval period</li>
+                <li>Check VS Code notification settings</li>
+                <li>Try toggling notifications off and on again</li>
+            </ul>
+
+            <h3>Performance Issues</h3>
+            <p><strong>Solution:</strong></p>
+            <ul>
+                <li>The extension is designed to be lightweight</li>
+                <li>If experiencing issues, try increasing inactivity timeout</li>
+                <li>Check VS Code's Output panel for any error messages</li>
+                <li>Report persistent issues on GitHub</li>
+            </ul>
+        </section>
+
+        <!-- FAQ -->
+        <section id="faq" class="docs-section">
+            <h2>❓ Frequently Asked Questions</h2>
+
+            <h3>Does this extension send my data anywhere?</h3>
+            <p>No. All data is stored locally in VS Code's storage. Nothing is sent to external servers. Your privacy is fully protected.</p>
+
+            <h3>Will this slow down VS Code?</h3>
+            <p>No. The extension is designed to be lightweight and runs efficiently in the background without impacting performance.</p>
+
+            <h3>Can I use this for billing clients?</h3>
+            <p>Yes! The extension provides accurate time tracking that you can export and use for billing purposes. However, always review the tracked time before billing.</p>
+
+            <h3>What happens if I forget to close VS Code overnight?</h3>
+            <p>The smart activity detection will automatically pause tracking after the configured inactivity timeout (default: 2.5 minutes).</p>
+
+            <h3>Can I track time across multiple machines?</h3>
+            <p>Currently, data is stored locally per machine. To sync across machines, you would need to export and manually combine the data.</p>
+
+            <h3>How accurate is the time tracking?</h3>
+            <p>Very accurate! The extension tracks actual keyboard and mouse activity. It automatically excludes periods when you're away from your desk or not actively coding.</p>
+
+            <h3>Can I customize the charts and visualizations?</h3>
+            <p>The charts automatically adapt to your VS Code theme (light/dark). Currently, chart types are fixed, but we're considering adding customization options in future versions.</p>
+
+            <h3>Is my data backed up?</h3>
+            <p>Data is stored in VS Code's storage, which persists across sessions. However, it's not automatically backed up. Use the export feature to create manual backups.</p>
+        </section>
+
+        <!-- Footer Links -->
+        <div style="text-align: center; margin-top: 60px; padding: 40px 0; border-top: 2px solid var(--border-color);">
+            <h3>Need More Help?</h3>
+            <p style="margin-bottom: 20px;">Check out these additional resources:</p>
+            <div style="display: flex; gap: 20px; justify-content: center; flex-wrap: wrap;">
+                <a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki" class="btn btn-secondary" target="_blank">Wiki Documentation</a>
+                <a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker/issues" class="btn btn-secondary" target="_blank">Report an Issue</a>
+                <a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker" class="btn btn-secondary" target="_blank">View on GitHub</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>Simple Coding Time Tracker</h4>
+                    <p>Track and visualize your coding time with precision</p>
+                </div>
+                <div class="footer-section">
+                    <h4>Resources</h4>
+                    <ul>
+                        <li><a href="index.html">Home</a></li>
+                        <li><a href="documentation.html">Documentation</a></li>
+                        <li><a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki" target="_blank">Wiki</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>Install</h4>
+                    <ul>
+                        <li><a href="https://marketplace.visualstudio.com/items?itemName=noorashuvo.simple-coding-time-tracker" target="_blank">VS Code Marketplace</a></li>
+                        <li><a href="https://open-vsx.org/extension/noorashuvo/simple-coding-time-tracker" target="_blank">Open VSX Registry</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 Simple Coding Time Tracker. Licensed under MIT License.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Simple Coding Time Tracker - Track and visualize your coding time across projects with this powerful VS Code extension">
+    <meta name="keywords" content="VS Code, extension, time tracker, coding time, productivity, developer tools">
+    <meta name="author" content="Simple Coding Time Tracker Team">
+    <title>Simple Coding Time Tracker - Track Your Coding Time in VS Code</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="icon" type="image/png" href="../icon-sctt.png">
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar">
+        <div class="container nav-container">
+            <div class="logo">
+                <img src="../icon-sctt.png" alt="SCTT Logo" class="logo-img">
+                <span class="logo-text">Simple Coding Time Tracker</span>
+            </div>
+            <ul class="nav-links">
+                <li><a href="#features">Features</a></li>
+                <li><a href="#screenshots">Screenshots</a></li>
+                <li><a href="#installation">Installation</a></li>
+                <li><a href="documentation.html">Documentation</a></li>
+                <li><a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker" class="github-link" target="_blank">GitHub</a></li>
+            </ul>
+            <button class="mobile-menu-toggle" aria-label="Toggle mobile menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="hero">
+        <div class="container">
+            <div class="hero-content">
+                <h1 class="hero-title">Track Your Coding Time with Precision</h1>
+                <p class="hero-subtitle">A powerful VS Code extension that helps you monitor and analyze your coding time across projects, branches, and programming languages</p>
+                <div class="hero-buttons">
+                    <a href="https://marketplace.visualstudio.com/items?itemName=noorashuvo.simple-coding-time-tracker" class="btn btn-primary" target="_blank">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M21.29 4.11L20.96 2h-2.09l.19 1.49c-1.86.42-3.48.97-5.06 1.59L12 2L9.98 5.09c-1.58-.62-3.2-1.17-5.06-1.59L5.13 2H3.04l-.33 2.11c-.57 3.64-.36 7.32 1.2 10.74l.1.25c.69 1.51 1.75 2.83 3.12 3.71 1.35.87 2.98 1.3 4.87 1.3 1.89 0 3.52-.43 4.87-1.3 1.37-.88 2.43-2.2 3.12-3.71l.1-.25c1.56-3.42 1.77-7.1 1.2-10.74zM12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6z"/>
+                        </svg>
+                        Install from VS Code Marketplace
+                    </a>
+                    <a href="https://open-vsx.org/extension/noorashuvo/simple-coding-time-tracker" class="btn btn-secondary" target="_blank">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2L2 7v10c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-10-5z"/>
+                        </svg>
+                        Install from Open VSX
+                    </a>
+                </div>
+                <div class="hero-stats">
+                    <div class="stat">
+                        <div class="stat-number">50+</div>
+                        <div class="stat-label">Languages Supported</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-number">Auto</div>
+                        <div class="stat-label">Branch Tracking</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-number">Smart</div>
+                        <div class="stat-label">Activity Detection</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Features Section -->
+    <section id="features" class="features">
+        <div class="container">
+            <h2 class="section-title">Powerful Features</h2>
+            <p class="section-subtitle">Everything you need to understand your coding habits</p>
+            
+            <div class="features-grid">
+                <div class="feature-card">
+                    <div class="feature-icon">⏱️</div>
+                    <h3>Automatic Time Tracking</h3>
+                    <p>Seamlessly tracks your coding time in the background. No manual start/stop needed.</p>
+                </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">🌿</div>
+                    <h3>Git Branch Tracking</h3>
+                    <p>Automatically tracks time spent on different Git branches for comprehensive analysis.</p>
+                </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">💻</div>
+                    <h3>Language Detection</h3>
+                    <p>Supports 50+ programming languages with automatic detection based on file extensions.</p>
+                </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">🎯</div>
+                    <h3>Smart Activity Detection</h3>
+                    <p>Automatically pauses tracking during periods of inactivity with configurable timeouts.</p>
+                </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">🔍</div>
+                    <h3>Advanced Filtering</h3>
+                    <p>Filter data by date range, project, branch, and programming language for detailed insights.</p>
+                </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">📊</div>
+                    <h3>Interactive Visualizations</h3>
+                    <p>Beautiful charts including project distribution, daily timeline, activity heatmap, and language breakdown.</p>
+                </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">🎨</div>
+                    <h3>Theme-Aware Design</h3>
+                    <p>Automatically adapts to VS Code's light and dark themes for a seamless experience.</p>
+                </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">💪</div>
+                    <h3>Health Notifications</h3>
+                    <p>Proactive reminders for eye rest (20-20-20 rule), stretching, and breaks based on scientific intervals.</p>
+                </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">⚙️</div>
+                    <h3>Dedicated Settings View</h3>
+                    <p>Easy-to-use interface for configuring all extension options with validation and descriptions.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Screenshots Section -->
+    <section id="screenshots" class="screenshots">
+        <div class="container">
+            <h2 class="section-title">See It In Action</h2>
+            <p class="section-subtitle">Beautiful, intuitive interface that adapts to your theme</p>
+            
+            <div class="screenshot-showcase">
+                <div class="screenshot-item">
+                    <h3>Light Theme - Comprehensive Dashboard</h3>
+                    <img src="https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/sctt-light.png" alt="Summary View Light Theme" class="screenshot-img">
+                    <p>View detailed reports with interactive charts, project distribution, and daily activity timeline</p>
+                </div>
+
+                <div class="screenshot-item">
+                    <h3>Dark Theme - Seamless Integration</h3>
+                    <img src="https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/sctt-dark.png" alt="Summary View Dark Theme" class="screenshot-img">
+                    <p>Theme-aware visualizations that perfectly match your VS Code appearance</p>
+                </div>
+
+                <div class="screenshot-features">
+                    <div class="screenshot-feature">
+                        <h4>Status Bar Integration</h4>
+                        <img src="https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/statusbar.png" alt="Status Bar" class="screenshot-small">
+                        <p>Real-time display of today's coding time, resets daily at midnight</p>
+                    </div>
+
+                    <div class="screenshot-feature">
+                        <h4>Detailed Tooltips</h4>
+                        <img src="https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/tooltip.png" alt="Tooltip" class="screenshot-small">
+                        <p>Hover for weekly, monthly, and all-time statistics</p>
+                    </div>
+
+                    <div class="screenshot-feature">
+                        <h4>Easy Settings Management</h4>
+                        <img src="https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/settings.png" alt="Settings View" class="screenshot-small">
+                        <p>Intuitive settings interface with clear descriptions and validation</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Installation Section -->
+    <section id="installation" class="installation">
+        <div class="container">
+            <h2 class="section-title">Easy Installation</h2>
+            <p class="section-subtitle">Get started in seconds</p>
+            
+            <div class="installation-methods">
+                <div class="install-method">
+                    <h3>Method 1: VS Code Marketplace</h3>
+                    <ol>
+                        <li>Open Visual Studio Code</li>
+                        <li>Go to Extensions view (<code>Ctrl+Shift+X</code> or <code>Cmd+Shift+X</code> on macOS)</li>
+                        <li>Search for "Simple Coding Time Tracker"</li>
+                        <li>Click "Install"</li>
+                    </ol>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=noorashuvo.simple-coding-time-tracker" class="btn btn-primary" target="_blank">Install from Marketplace</a>
+                </div>
+
+                <div class="install-method">
+                    <h3>Method 2: Open VSX Registry</h3>
+                    <p class="install-description">For Cursor, Windsurf, Trae, VS Codium, and other compatible editors</p>
+                    <ol>
+                        <li>Open your editor's extensions view</li>
+                        <li>Search for "Simple Coding Time Tracker"</li>
+                        <li>Click "Install"</li>
+                    </ol>
+                    <a href="https://open-vsx.org/extension/noorashuvo/simple-coding-time-tracker" class="btn btn-secondary" target="_blank">Install from Open VSX</a>
+                </div>
+            </div>
+
+            <div class="quick-start">
+                <h3>Quick Start Guide</h3>
+                <div class="quick-start-steps">
+                    <div class="quick-step">
+                        <div class="step-number">1</div>
+                        <div class="step-content">
+                            <h4>Install the Extension</h4>
+                            <p>Use either VS Code Marketplace or Open VSX Registry</p>
+                        </div>
+                    </div>
+                    <div class="quick-step">
+                        <div class="step-number">2</div>
+                        <div class="step-content">
+                            <h4>Start Coding</h4>
+                            <p>The extension automatically starts tracking when you begin coding</p>
+                        </div>
+                    </div>
+                    <div class="quick-step">
+                        <div class="step-number">3</div>
+                        <div class="step-content">
+                            <h4>View Your Stats</h4>
+                            <p>Click the status bar or run <code>SCTT: Show Coding Time Summary</code></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Use Cases Section -->
+    <section class="use-cases">
+        <div class="container">
+            <h2 class="section-title">Perfect For</h2>
+            <div class="use-cases-grid">
+                <div class="use-case">
+                    <div class="use-case-icon">👨‍💻</div>
+                    <h3>Freelance Developers</h3>
+                    <p>Track billable hours accurately across multiple client projects</p>
+                </div>
+                <div class="use-case">
+                    <div class="use-case-icon">🏢</div>
+                    <h3>Development Teams</h3>
+                    <p>Understand project time allocation and improve team productivity</p>
+                </div>
+                <div class="use-case">
+                    <div class="use-case-icon">📚</div>
+                    <h3>Students & Learners</h3>
+                    <p>Monitor learning progress and maintain consistent coding practice</p>
+                </div>
+                <div class="use-case">
+                    <div class="use-case-icon">📈</div>
+                    <h3>Productivity Enthusiasts</h3>
+                    <p>Analyze coding habits and optimize workflow efficiency</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA Section -->
+    <section class="cta">
+        <div class="container">
+            <h2>Start Tracking Your Coding Time Today</h2>
+            <p>Join developers worldwide who are gaining insights into their coding habits</p>
+            <div class="cta-buttons">
+                <a href="https://marketplace.visualstudio.com/items?itemName=noorashuvo.simple-coding-time-tracker" class="btn btn-primary btn-large" target="_blank">Get Started Now</a>
+                <a href="documentation.html" class="btn btn-secondary btn-large">Read Documentation</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h4>Simple Coding Time Tracker</h4>
+                    <p>Track and visualize your coding time with precision</p>
+                    <div class="footer-links">
+                        <a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker" target="_blank">GitHub</a>
+                        <a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki" target="_blank">Wiki</a>
+                        <a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker/issues" target="_blank">Issues</a>
+                    </div>
+                </div>
+                <div class="footer-section">
+                    <h4>Resources</h4>
+                    <ul>
+                        <li><a href="documentation.html">Documentation</a></li>
+                        <li><a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki/Health-Notifications">Health Guide</a></li>
+                        <li><a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki/Time-Tracking">Time Tracking Guide</a></li>
+                        <li><a href="https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki/Test-Scenarios">Test Scenarios</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>Install</h4>
+                    <ul>
+                        <li><a href="https://marketplace.visualstudio.com/items?itemName=noorashuvo.simple-coding-time-tracker" target="_blank">VS Code Marketplace</a></li>
+                        <li><a href="https://open-vsx.org/extension/noorashuvo/simple-coding-time-tracker" target="_blank">Open VSX Registry</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 Simple Coding Time Tracker. Licensed under MIT License.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,0 +1,236 @@
+// Mobile Menu Toggle
+document.addEventListener('DOMContentLoaded', function() {
+    const mobileMenuToggle = document.querySelector('.mobile-menu-toggle');
+    const navLinks = document.querySelector('.nav-links');
+    
+    if (mobileMenuToggle) {
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('active');
+            
+            // Animate hamburger icon
+            const spans = this.querySelectorAll('span');
+            spans[0].style.transform = navLinks.classList.contains('active') ? 
+                'rotate(-45deg) translate(-5px, 6px)' : 'none';
+            spans[1].style.opacity = navLinks.classList.contains('active') ? '0' : '1';
+            spans[2].style.transform = navLinks.classList.contains('active') ? 
+                'rotate(45deg) translate(-5px, -6px)' : 'none';
+        });
+    }
+
+    // Close mobile menu when clicking on a link
+    const navLinkItems = document.querySelectorAll('.nav-links a');
+    navLinkItems.forEach(link => {
+        link.addEventListener('click', () => {
+            if (navLinks.classList.contains('active')) {
+                navLinks.classList.remove('active');
+                const spans = mobileMenuToggle.querySelectorAll('span');
+                spans[0].style.transform = 'none';
+                spans[1].style.opacity = '1';
+                spans[2].style.transform = 'none';
+            }
+        });
+    });
+
+    // Smooth scrolling for anchor links
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+        anchor.addEventListener('click', function (e) {
+            e.preventDefault();
+            const target = document.querySelector(this.getAttribute('href'));
+            if (target) {
+                const offsetTop = target.offsetTop - 80; // Account for fixed navbar
+                window.scrollTo({
+                    top: offsetTop,
+                    behavior: 'smooth'
+                });
+            }
+        });
+    });
+
+    // Intersection Observer for fade-in animations
+    const observerOptions = {
+        threshold: 0.1,
+        rootMargin: '0px 0px -100px 0px'
+    };
+
+    const observer = new IntersectionObserver(function(entries) {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.style.opacity = '1';
+                entry.target.style.transform = 'translateY(0)';
+            }
+        });
+    }, observerOptions);
+
+    // Observe feature cards
+    const featureCards = document.querySelectorAll('.feature-card');
+    featureCards.forEach((card, index) => {
+        card.style.opacity = '0';
+        card.style.transform = 'translateY(30px)';
+        card.style.transition = `opacity 0.6s ease-out ${index * 0.1}s, transform 0.6s ease-out ${index * 0.1}s`;
+        observer.observe(card);
+    });
+
+    // Observe use case cards
+    const useCases = document.querySelectorAll('.use-case');
+    useCases.forEach((useCase, index) => {
+        useCase.style.opacity = '0';
+        useCase.style.transform = 'translateY(30px)';
+        useCase.style.transition = `opacity 0.6s ease-out ${index * 0.1}s, transform 0.6s ease-out ${index * 0.1}s`;
+        observer.observe(useCase);
+    });
+
+    // Observe installation methods
+    const installMethods = document.querySelectorAll('.install-method');
+    installMethods.forEach((method, index) => {
+        method.style.opacity = '0';
+        method.style.transform = 'translateY(30px)';
+        method.style.transition = `opacity 0.6s ease-out ${index * 0.2}s, transform 0.6s ease-out ${index * 0.2}s`;
+        observer.observe(method);
+    });
+
+    // Navbar scroll effect
+    let lastScroll = 0;
+    const navbar = document.querySelector('.navbar');
+
+    window.addEventListener('scroll', () => {
+        const currentScroll = window.pageYOffset;
+
+        if (currentScroll <= 0) {
+            navbar.style.boxShadow = '0 2px 4px rgba(0,0,0,0.1)';
+        } else {
+            navbar.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
+        }
+
+        // Optional: Hide navbar on scroll down, show on scroll up
+        // if (currentScroll > lastScroll && currentScroll > 100) {
+        //     navbar.style.transform = 'translateY(-100%)';
+        // } else {
+        //     navbar.style.transform = 'translateY(0)';
+        // }
+
+        lastScroll = currentScroll;
+    });
+
+    // Add loading effect for images
+    const images = document.querySelectorAll('img');
+    images.forEach(img => {
+        img.addEventListener('load', function() {
+            this.style.opacity = '1';
+        });
+        
+        // Set initial opacity
+        if (!img.complete) {
+            img.style.opacity = '0';
+            img.style.transition = 'opacity 0.3s ease-in';
+        }
+    });
+
+    // Parallax effect for hero section (subtle)
+    const hero = document.querySelector('.hero');
+    if (hero) {
+        window.addEventListener('scroll', () => {
+            const scrolled = window.pageYOffset;
+            const rate = scrolled * 0.5;
+            hero.style.transform = `translate3d(0, ${rate}px, 0)`;
+        });
+    }
+
+    // Copy code snippets functionality (if needed in future)
+    const codeBlocks = document.querySelectorAll('code');
+    codeBlocks.forEach(code => {
+        code.style.cursor = 'pointer';
+        code.title = 'Click to copy';
+        
+        code.addEventListener('click', function() {
+            const text = this.textContent;
+            navigator.clipboard.writeText(text).then(() => {
+                // Show temporary tooltip
+                const tooltip = document.createElement('span');
+                tooltip.textContent = 'Copied!';
+                tooltip.style.cssText = `
+                    position: absolute;
+                    background: #007acc;
+                    color: white;
+                    padding: 4px 8px;
+                    border-radius: 4px;
+                    font-size: 12px;
+                    margin-left: 10px;
+                    animation: fadeOut 2s forwards;
+                `;
+                
+                this.parentElement.style.position = 'relative';
+                this.parentElement.appendChild(tooltip);
+                
+                setTimeout(() => tooltip.remove(), 2000);
+            });
+        });
+    });
+
+    // Add CSS for fadeOut animation
+    const style = document.createElement('style');
+    style.textContent = `
+        @keyframes fadeOut {
+            0% { opacity: 1; transform: translateY(0); }
+            70% { opacity: 1; transform: translateY(0); }
+            100% { opacity: 0; transform: translateY(-10px); }
+        }
+    `;
+    document.head.appendChild(style);
+
+    // Stats counter animation (when in viewport)
+    const stats = document.querySelectorAll('.stat-number');
+    const statsObserver = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting && entry.target.textContent !== 'Auto' && entry.target.textContent !== 'Smart') {
+                const finalValue = entry.target.textContent;
+                if (!isNaN(finalValue.replace('+', ''))) {
+                    animateCounter(entry.target, 0, parseInt(finalValue.replace('+', '')), 2000);
+                }
+                statsObserver.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.5 });
+
+    stats.forEach(stat => statsObserver.observe(stat));
+
+    function animateCounter(element, start, end, duration) {
+        const range = end - start;
+        const increment = range / (duration / 16);
+        let current = start;
+
+        const timer = setInterval(() => {
+            current += increment;
+            if (current >= end) {
+                element.textContent = end + '+';
+                clearInterval(timer);
+            } else {
+                element.textContent = Math.floor(current) + '+';
+            }
+        }, 16);
+    }
+
+    // Add active state to current nav link based on scroll position
+    const sections = document.querySelectorAll('section[id]');
+    
+    function highlightNavigation() {
+        const scrollY = window.pageYOffset;
+
+        sections.forEach(section => {
+            const sectionHeight = section.offsetHeight;
+            const sectionTop = section.offsetTop - 100;
+            const sectionId = section.getAttribute('id');
+            const navLink = document.querySelector(`.nav-links a[href="#${sectionId}"]`);
+
+            if (navLink && scrollY > sectionTop && scrollY <= sectionTop + sectionHeight) {
+                document.querySelectorAll('.nav-links a').forEach(link => {
+                    link.style.borderBottomColor = 'transparent';
+                });
+                navLink.style.borderBottomColor = 'var(--primary-color)';
+            }
+        });
+    }
+
+    window.addEventListener('scroll', highlightNavigation);
+
+    console.log('Simple Coding Time Tracker - Website loaded successfully! 🚀');
+});


### PR DESCRIPTION
This pull request introduces a comprehensive GitHub Pages website for the Simple Coding Time Tracker VS Code extension. It adds a detailed setup guide, a complete site under the `docs/` directory, and supporting documentation to help users deploy and customize their extension showcase site. The changes focus on improving user onboarding, providing robust documentation, and delivering a modern, responsive web presence for the extension.

**New Documentation and Guides:**

* Added `GITHUB_PAGES_SETUP.md` with step-by-step instructions for enabling and customizing GitHub Pages, troubleshooting tips, and guidance for linking the live site to extension metadata and marketplaces.
* Added `docs/README.md` describing the website structure, key features, technologies used, and instructions for local development and contribution.

**Website Implementation (`docs/` folder):**

* Added a fully-featured landing page in `docs/index.html` with navigation, hero section, feature showcase, screenshot gallery, installation instructions, use cases, and footer with resource links. The page is designed to be responsive, accessible, and visually appealing, matching VS Code's aesthetic.

These changes give the extension a professional, user-friendly web presence and make it easy for users to discover, install, and learn about its features.