### PR TITLE
Fixed Daily Average and Time summary graphs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,8 +167,30 @@ export function activate(context: vscode.ExtensionContext) {
             'php', 'ruby', 'swift', 'kotlin', 'html', 'css', 'scss', 'json', 'yaml', 'markdown', 'sql', 'bash'
         ];
 
+        const value = await vscode.window.showInputBox({
+            title: 'Enter the number of days which should be generated',
+            prompt: 'Please enter the number of days',
+            placeHolder: '90 to generate entries for the last 90 days',
+            validateInput: (input) => {
+                if(isNaN(Number(input))) {
+                    return 'Must be a number';
+                }
+                // Only Positive integers without 0
+                if(!(/^[1-9][[0-9]*$/.test(input))) {
+                    return 'Enter an integer greater than 0';
+                }
+                return null
+            }
+        })
+
+        if (value == undefined) {
+            // user cancelled the input
+            return;
+        }
+
         const today = new Date();
         let totalEntries = 0;
+        const days = Number(value);
 
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
@@ -176,8 +198,8 @@ export function activate(context: vscode.ExtensionContext) {
             cancellable: false
         }, async (progress) => {
             try {
-                // Generate data for the last 90 days
-                for (let i = 0; i < 90; i++) {
+                // Generate data for the last x days
+                for (let i = 0; i < days; i++) {
                     const date = new Date(today);
                     date.setDate(date.getDate() - i);
                     
@@ -200,7 +222,7 @@ export function activate(context: vscode.ExtensionContext) {
                     }
                     
                     // Update progress
-                    progress.report({ increment: (1/90) * 100 });
+                    progress.report({ increment: (1/days) * 100 });
                 }
 
                 // Add some special test cases for yesterday and today
@@ -218,7 +240,7 @@ export function activate(context: vscode.ExtensionContext) {
             }
         });
 
-        vscode.window.showInformationMessage(`✅ Generated ${totalEntries} test entries successfully!`);
+        vscode.window.showInformationMessage(`✅ Generated ${totalEntries} test entries for ${days} days successfully!`);
     });
 
     // Delete test data command

--- a/src/summaryView.ts
+++ b/src/summaryView.ts
@@ -1738,7 +1738,9 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
 
                     function updateDailyAverageAnalytics(data, allEntries) {
                         const last30Days = getLast30DaysData(allEntries);
-                        const avgTime = last30Days.reduce((sum, day) => sum + day.time, 0) / 30;
+                        let firstActiveDay = last30Days.findIndex((value, index, obj) => value.time > 0);
+                        const numberOfDays = Math.min(30, 30 - firstActiveDay);
+                        const avgTime = last30Days.reduce((sum, day) => sum + day.time, 0) / numberOfDays;
                         
                         document.getElementById('daily-average').textContent = formatTime(avgTime);
                         

--- a/src/summaryView.ts
+++ b/src/summaryView.ts
@@ -1312,10 +1312,11 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                                     y: { 
                                         display: true,
                                         ticks: {
+                                            autoSkip: false,
                                             font: {
                                                 size: 9
                                             },
-                                            color: 'var(--vscode-foreground)',
+                                            color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-foreground') || '#000',
                                             padding: 5
                                         },
                                         grid: {


### PR DESCRIPTION
## The daily average graph used for average time always 30 days even if there are not enough entries
The graph will now still show the last 30 days even if there are no entries for it. 
But for the calculation of average it will use only the last number of days which are not 0. 

### Example 
If in the last 30 days only the last 5 days have an entry the average will be the sum of all entries divided by 5.
If in the last 30 days only the first 5 days have and entry the average will be the summ of all entries divided by 30.

***After writing this down I am not sure any more this is more intuitive than it was before let me know what you think.***

## Extend command generate test data
I added extended functionality to the generate test data command to allow testing this probably. The generate test data command now will ask for a number of days to generate 

## The Time Summary Graph Skipped Labels and color
The time summary graph skipped labels for 'This week' and 'This year' and the labels do not use the foreground color for dark theme
<img width="208" height="163" alt="image" src="https://github.com/user-attachments/assets/5c0981a3-8a1a-43b5-a487-fa9cdf18dcdf" />

### With the fix
#### Light theme
<img width="211" height="155" alt="image" src="https://github.com/user-attachments/assets/bfd7fd90-3347-4221-93b2-30e394203d4c" />

#### Dark theme 
<img width="201" height="158" alt="image" src="https://github.com/user-attachments/assets/1c61c3c4-19c9-446d-8fbc-c6b910f8e827" />


