### PR TITLE
Rebrand to Dev Pulse: focus-based tracking, remove inactivity detection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ For testing packaged extensions:
 1. **Enable test commands**:
    - Open Settings (`Ctrl+,`)
    - Search `"enableDevCommands"`
-   - Enable "Simple Coding Time Tracker › Enable Dev Commands"
+   - Enable "Dev Pulse › Enable Dev Commands"
 
 2. **Generate test data**:
    - Press `Ctrl+Shift+P`

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 🌐 **Website**: [https://twentytwo.github.io/vsc-ext-coding-time-tracker/](https://twentytwo.github.io/vsc-ext-coding-time-tracker/)
 
-**📖 For detailed configuration, advanced features, and complete documentation, see the [Simple Coding Time Tracker Guide](https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki) in our wiki.**
+**📖 For detailed configuration, advanced features, and complete documentation, see the [Dev Pulse Guide](https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki) in our wiki.**
 
 📦 **Installation:** [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=noorashuvo.simple-coding-time-tracker) (VS Code) | [Open VSX Registry](https://open-vsx.org/extension/noorashuvo/simple-coding-time-tracker) (Cursor, Windsurf, Trae, VS Codium etc) 
 
 
-# Simple Coding Time Tracker: A Visual Studio Code Extension
+# Dev Pulse: A Visual Studio Code Extension
 <div style="display: flex; align-items: center;">
-  <img src="icon-sctt.png" alt="Simple Coding Time Tracker Icon" width="100" style="margin-right: 20px;">
+  <img src="icon-sctt.png" alt="Dev Pulse Icon" width="100" style="margin-right: 20px;">
 </div>
 
-Simple Coding Time Tracker is a powerful extension for Visual Studio Code that helps you monitor and analyze your coding time. If you are curious about your coding habits, this extension covers you.
+Dev Pulse (formerly Simple Coding Time Tracker) is a powerful extension for Visual Studio Code that helps you monitor and analyze your dev time. Your Dev Pulse counts any time VS Code is the focused window — coding, chatting with an AI assistant, running terminal commands, reading docs — not just literal keystrokes in the editor. If you are curious about your coding habits, this extension covers you.
 
 ## Features
 
-- **Automatic Time Tracking**: Seamlessly tracks your coding time in the background.
+- **Automatic Time Tracking**: Seamlessly tracks your Dev Pulse in the background, based on VS Code window focus.
 - **Project and Branch Tracking**: Organizes time data by project and Git branches for comprehensive analysis.
 - **Language Tracking**: Automatically detects and tracks time spent in different programming languages.
-- **Smart Activity Detection**: Automatically pauses tracking during periods of inactivity.
-- **Focused Work Detection**: Intelligently tracks time even when VS Code isn't focused.
+- **Whole-Window Activity**: Counts time in the editor, AI chat panels, and the integrated terminal alike — anything within the focused VS Code window.
+- **Focused Work Detection**: Briefly switching to another app (e.g. checking a message) doesn't lose your progress — tracking pauses only after you've been away longer than the configurable Focus Timeout.
 - **Health Notification System**: Proactive reminders to promote healthy coding habits with scientifically backed intervals.
 - **Dedicated Settings View**: Comprehensive settings interface accessible via the summary view with easy-to-use controls for all configuration options.
 - **Customizable Status Bar**:
@@ -33,7 +33,7 @@ Simple Coding Time Tracker is a powerful extension for Visual Studio Code that h
   - Languages Used: Count of languages with most-used language highlight
   - Projects Worked: Number of projects with most active project highlight
   - Longest Streak: Track your coding streak with animated flame indicator
-- **Coding Time Analytics**:
+- **Dev Pulse Analytics**:
   - Time Summary: Horizontal bar chart comparing today, week, month, year, and all-time totals
   - Daily Average: Visual breakdown of daily coding patterns
   - Weekly Progress: Line chart showing weekly trends
@@ -53,7 +53,7 @@ Simple Coding Time Tracker is a powerful extension for Visual Studio Code that h
 - **Data Persistence**: Safely stores your time data for long-term analysis.
 
 ## Time Tracking Details
-The extension tracks your coding time by monitoring file changes and user activity within Visual Studio Code. It uses a combination of timers and event listeners to ensure accurate tracking without impacting performance. The extension automatically detects the programming language you're working with based on file extensions and VS Code's language detection.
+Dev Pulse tracks time based on whether the VS Code window is focused — not just editor keystrokes. That means coding, chatting with an AI assistant in a sidebar panel, and running commands in the integrated terminal all count, as long as VS Code is the window you're actually using. Tracking pauses only once you switch away from VS Code for longer than the **Focus Timeout** (default 3 minutes); switching back within that window resumes seamlessly with no time lost. The extension automatically detects the programming language you're working with based on file extensions and VS Code's language detection.
 
 **📖 For detailed configuration, advanced features, and complete documentation, see the [Time Tracking Guide](https://github.com/twentyTwo/vsc-ext-coding-time-tracker/wiki/Time-Tracking) in our wiki.**
 
@@ -73,12 +73,12 @@ These are default values and designed to help you maintain focus and prevent fat
 
 1. Open Visual Studio Code
 2. Go to the Extensions view (Ctrl+Shift+X or Cmd+Shift+X on macOS)
-3. Search for "Simple Coding Time Tracker"
+3. Search for "Dev Pulse" or "Simple Coding Time Tracker"
 4. Click "Install"
 
 ## Usage
 
-Once installed, the extension will automatically start tracking your coding time. You can view your current session time in the status bar at the bottom of the VSCode window.
+Once installed, the extension will automatically start tracking your Dev Pulse. You can view your current session time in the status bar at the bottom of the VSCode window.
 
 ### Using Search & Filters
 
@@ -99,25 +99,23 @@ The charts and visualizations will automatically update to reflect your selected
 You can customize the extension's behavior through VS Code settings or the dedicated Settings view:
 
 **Method 1: Using the Settings View (Recommended)**
-1. Open the Coding Time Summary view by clicking on the status bar or using the command `SCTT: Show Coding Time Summary`
+1. Open the Dev Pulse Summary view by clicking on the status bar or using the command `SCTT: Show Dev Pulse Summary`
 2. Click the "Settings" button in the top-right corner of the summary view
 3. Configure all settings through the user-friendly interface with descriptions and validation
 4. Click "Save Settings" to apply changes
 
 **Method 2: Using VS Code Settings**
 1. Open VS Code Settings (Ctrl+, or Cmd+, on macOS)
-2. Search for "Simple Coding Time Tracker"
+2. Search for "Dev Pulse" or "Simple Coding Time Tracker"
 
 **Available settings:**  
    - **Time Tracking Settings**:
-     - **Inactivity Timeout**: How long to wait before stopping the timer when no activity is detected but you are focused on VS Code (in minutes)
-       - Default: 2.5 minutes
-       - Lower values will stop tracking sooner when you're not actively coding
-       - Higher values will continue tracking for longer during breaks
      - **Focus Timeout**: How long to continue tracking after VS Code loses focus (in minutes)
        - Default: 3 minutes
+       - This is the only condition that pauses tracking — coding, AI chat, and terminal use all count as long as the window stays focused
        - Determines how long to keep tracking when you switch to other applications
        - Useful for when you're referencing documentation or testing your application
+     - **Inactivity Timeout** *(deprecated)*: previously stopped the timer after a period with no editor keystrokes; no longer used now that Dev Pulse tracks by window focus. Kept only so existing settings don't error.
    
    - **Status Bar Display Settings**:
      - **Show Seconds**: Display seconds in the status bar time (HH:MM:SS)
@@ -148,14 +146,14 @@ You can customize the extension's behavior through VS Code settings or the dedic
 
 ## Screenshots
 
-### Coding time summary
-The summary page provides a detailed report of your coding activity with interactive charts and visualizations:
+### Dev Pulse summary
+The summary page provides a detailed report of your dev activity with interactive charts and visualizations:
 - **Developer Insights Dashboard**:
   - Most Productive Day with average time breakdown
   - Languages Used count with most-used language highlight
   - Projects Worked count with most active project highlight
   - Longest Streak tracking with animated flame indicator
-- **Coding Time Analytics**:
+- **Dev Pulse Analytics**:
   - Time Summary comparing today, week, month, year, and all-time totals
   - Daily Average showing coding patterns over last 30 days
   - Weekly Progress line chart with trend visualization
@@ -175,18 +173,18 @@ The summary page provides a detailed report of your coding activity with interac
   - Click status bar timer to save session and open summary
   - Bell icon shows health notification status at a glance
 
-![Coding Summary](https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/sctt-light.png)
+![Dev Pulse Summary](https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/sctt-light.png)
 
 #### Dark theme
-![Coding Summary Dark Theme](https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/sctt-dark.png)
+![Dev Pulse Summary Dark Theme](https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/sctt-dark.png)
 
 
 #### Status Bar
-Status bar resets to zero at midnight each day and hence shows the coding time for the current day.
+Status bar resets to zero at midnight each day and hence shows the Dev Pulse for the current day.
 ![Status Bar](https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/statusbar.png)
 
 #### Tooltip
-Tooltip shows the total coding time weekly, monthly and all time basis.
+Tooltip shows the total Dev Pulse weekly, monthly and all time basis.
 ![Tooltip](https://raw.githubusercontent.com/twentyTwo/static-file-hosting/main/vsc-ext-coding-time-tracker-files/tooltip.png)
 
 
@@ -211,7 +209,7 @@ For developers and testers, the extension includes built-in test data generation
 ### Enabling Test Commands
 1. Open Settings (`Ctrl+,`)
 2. Search: `"enableDevCommands"`  
-3. Enable "Simple Coding Time Tracker › Enable Dev Commands"
+3. Enable "Dev Pulse › Enable Dev Commands"
 
 ### Available Test Commands
 - **`SCTT: Generate Test Data (Dev)`** - Creates realistic test data for 90 days
@@ -226,6 +224,14 @@ For complete testing documentation, see [TECHNICAL.md](TECHNICAL.md).
 For technical details about development, release process, and internal architecture, please see [TECHNICAL.md](TECHNICAL.md).
 
 ## Changelog
+
+### [0.8.0] - 2026-08-28
+- Renamed "Coding Time" to **Dev Pulse** throughout the UI to reflect what's actually measured
+- Redefined tracking to be based on VS Code window focus rather than editor-only keystroke/cursor activity — time spent in AI chat panels or the integrated terminal now counts as long as the VS Code window stays focused
+- Removed the editor-activity-based inactivity auto-stop; **Focus Timeout** (switching away from VS Code) is now the only condition that pauses tracking
+- Deprecated the **Inactivity Timeout** setting (no longer used; kept so existing configurations don't error)
+- Added detection for OS sleep/lock gaps so a suspended laptop doesn't get counted as tracked time while the window remains reported as focused
+- Fixed a bug where tracking could fail to start if VS Code was focused for the first time without first losing and regaining focus
 
 ### [0.7.0] - 2026-1-18
 - Added comprehensive status bar customization options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-coding-time-tracker",
-  "version": "0.4.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-coding-time-tracker",
-      "version": "0.4.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "simple-git": "^3.27.0"
@@ -23,7 +23,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.63.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "simple-coding-time-tracker",
-  "displayName": "Simple Coding Time Tracker",
-  "description": "Automatic time tracking for VS Code — Track coding time per project, branch & language with smart activity detection, health reminders, and beautiful visualizations",
-  "version": "0.7.7",
+  "displayName": "Dev Pulse - Simple Coding Time Tracker",
+  "description": "Automatic time tracking for VS Code — Your Dev Pulse counts any time VS Code is focused (coding, AI chat, terminal) per project, branch & language, with health reminders and beautiful visualizations",
+  "version": "0.8.0",
   "publisher": "noorashuvo",
   "license": "MIT",
   "icon": "icon-sctt.png",
@@ -17,6 +17,7 @@
     "time tracker",
     "time tracking",
     "coding time",
+    "dev pulse",
     "productivity",
     "analytics",
     "statistics",
@@ -37,21 +38,22 @@
   "main": "./dist/extension.js",
   "contributes": {
     "configuration": {
-      "title": "Simple Coding Time Tracker",
+      "title": "Dev Pulse",
       "properties": {
         "simpleCodingTimeTracker.inactivityTimeout": {
           "type": "number",
           "default": 2.5,
           "minimum": 0.5,
           "maximum": 60,
-          "description": "Pause tracking if there is no keyboard or mouse activity in VS Code for this many minutes."
+          "deprecationMessage": "No longer used — Dev Pulse now tracks based on VS Code window focus rather than editor keystroke/cursor activity, so time in AI chat panels or the terminal counts too. Use 'Focus Timeout' instead.",
+          "description": "Deprecated. Previously paused tracking after this many minutes of no keyboard/mouse activity in the editor; no longer used."
         },
         "simpleCodingTimeTracker.focusTimeout": {
           "type": "number",
           "default": 3,
           "minimum": 0.5,
           "maximum": 60,
-          "description": "If you switch away from VS Code, continue counting as coding time for up to this many minutes before pausing."
+          "description": "If you switch away from VS Code, continue counting as Dev Pulse for up to this many minutes before pausing. This is now the only pause condition — coding, AI chat, and terminal use all count as long as the VS Code window stays focused."
         },
         "simpleCodingTimeTracker.statusBar.showSeconds": {
           "type": "boolean",
@@ -77,7 +79,7 @@
         "simpleCodingTimeTracker.health.enableNotifications": {
           "type": "boolean",
           "default": false,
-          "description": "Enable health notifications during coding sessions"
+          "description": "Enable health notifications during dev sessions"
         },
         "simpleCodingTimeTracker.health.modalNotifications": {
           "type": "boolean",
@@ -103,7 +105,7 @@
           "default": 90,
           "minimum": 30,
           "maximum": 480,
-          "description": "Coding duration before suggesting a break (minutes) - Based on ultradian rhythms"
+          "description": "Dev Pulse duration before suggesting a break (minutes) - Based on ultradian rhythms"
         },
         "simpleCodingTimeTracker.enableDevCommands": {
           "type": "boolean",
@@ -116,7 +118,7 @@
     "commands": [
       {
         "command": "simpleCodingTimeTracker.showSummary",
-        "title": "SCTT: Show Coding Time Summary"
+        "title": "SCTT: Show Dev Pulse Summary"
       },
       {
         "command": "simpleCodingTimeTracker.viewStorageData",

--- a/src/database.ts.md
+++ b/src/database.ts.md
@@ -1,15 +1,15 @@
 # `database.ts` Documentation
 
-This file implements the persistent storage and retrieval logic for the VS Code Coding Time Tracker extension. It manages time tracking entries, provides summary data, and supports search and data management operations.
+This file implements the persistent storage and retrieval logic for the VS Code Dev Pulse extension. It manages time tracking entries, provides summary data, and supports search and data management operations.
 
 ## Overview
-- **Purpose:** Store and manage coding time entries, including date, project, time spent, and branch information.
+- **Purpose:** Store and manage Dev Pulse entries, including date, project, time spent, and branch information.
 - **Storage:** Uses VS Code's `globalState` API for persistent storage across extension reloads.
 - **Main Class:** `Database` – encapsulates all database operations.
 
 ## Key Concepts
 - **TimeEntry:**
-  - Represents a single tracked coding session.
+  - Represents a single tracked Dev Pulse session.
   - Fields: `date` (YYYY-MM-DD), `project` (string), `timeSpent` (number, minutes), `branch` (string), `language` (string).
 - **SummaryData:**
   - Aggregated statistics for reporting (daily, per project, per branch, per language, total time).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -298,24 +298,12 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(statusBar);
     context.subscriptions.push(settingsView);
 
-    // Start tracking immediately if VS Code is already focused
+    // Start tracking immediately if VS Code is already focused.
+    // All other start/stop handling (including focus regained) lives in
+    // TimeTracker's own onDidChangeWindowState listener.
     if (vscode.window.state.focused) {
         timeTracker.startTracking('initial startup');
     }
-
-    // Window state is now handled in TimeTracker class
-    vscode.window.onDidChangeWindowState((e: vscode.WindowState) => {
-        if (e.focused && !timeTracker.isActive()) {
-            timeTracker.startTracking('window focus');
-        }
-    });
-
-    vscode.workspace.onDidOpenTextDocument(() => {
-        if (vscode.window.state.focused) {
-            timeTracker.startTracking('document opened');
-        }
-    });
-
 }
 
 export function deactivate() {}

--- a/src/extension.ts.md
+++ b/src/extension.ts.md
@@ -1,6 +1,6 @@
 # `extension.ts` Documentation
 
-This file is the main entry point for the VS Code Coding Time Tracker extension. It registers commands, initializes the database, and sets up the extension's UI components and event listeners.
+This file is the main entry point for the VS Code Dev Pulse extension. It registers commands, initializes the database, and sets up the extension's UI components and event listeners.
 
 ## Overview
 - **Purpose:** Bootstrap the extension, handle activation/deactivation, and wire up commands and UI.

--- a/src/healthNotifications.ts.md
+++ b/src/healthNotifications.ts.md
@@ -1,6 +1,6 @@
 # Health Notifications Implementation
 
-This document explains the implementation of the health notification system in the Simple Coding Time Tracker extension.
+This document explains the implementation of the health notification system in the Dev Pulse (Simple Coding Time Tracker) extension.
 
 ## Overview
 
@@ -62,7 +62,7 @@ Added to `package.json` configuration:
   "simpleCodingTimeTracker.health.enableNotifications": {
     "type": "boolean",
     "default": true,
-    "description": "Enable health notifications during coding sessions"
+    "description": "Enable health notifications during dev sessions"
   },
   "simpleCodingTimeTracker.health.eyeRestInterval": {
     "type": "number",
@@ -77,7 +77,7 @@ Added to `package.json` configuration:
   "simpleCodingTimeTracker.health.breakThreshold": {
     "type": "number",
     "default": 120,
-    "description": "Coding duration before suggesting a break (minutes)"
+    "description": "Dev Pulse duration before suggesting a break (minutes)"
   }
 }
 ```

--- a/src/settingsView.ts
+++ b/src/settingsView.ts
@@ -19,7 +19,7 @@ export class SettingsViewProvider {
 
         this.panel = vscode.window.createWebviewPanel(
             'scttSettings',
-            'Simple Coding Time Tracker - Settings',
+            'Dev Pulse - Settings',
             vscode.ViewColumn.One,
             {
                 enableScripts: true,
@@ -441,21 +441,21 @@ export class SettingsViewProvider {
     </style>
 </head>
 <body>
-    <h1>⚙️ Simple Coding Time Tracker Settings</h1>
+    <h1>⚙️ Dev Pulse Settings</h1>
 
     <div class="setting-group">
         <h2>⏱️ Time Tracking Settings</h2>
-        
+
         <div class="setting-item">
-            <label for="inactivityTimeout">Inactivity Timeout (minutes)</label>
-            <div class="description">Pause tracking if there is no keyboard or mouse activity in VS Code for this many minutes.</div>
-            <input type="number" id="inactivityTimeout" min="0.5" max="60" step="0.5" />
+            <label for="inactivityTimeout">Inactivity Timeout (minutes) — Deprecated</label>
+            <div class="description">No longer used. Dev Pulse now tracks based on VS Code window focus rather than editor keystroke/cursor activity, so time in AI chat panels or the terminal counts too. Use Focus Timeout below instead.</div>
+            <input type="number" id="inactivityTimeout" min="0.5" max="60" step="0.5" disabled />
             <div class="range-info">Range: 0.5 - 60 minutes</div>
         </div>
 
         <div class="setting-item">
             <label for="focusTimeout">Focus Timeout (minutes)</label>
-            <div class="description">If you switch away from VS Code, continue counting as coding time for up to this many minutes before pausing.</div>
+            <div class="description">If you switch away from VS Code, continue counting as Dev Pulse for up to this many minutes before pausing. This is the only pause condition — coding, AI chat, and terminal use all count as long as the VS Code window stays focused.</div>
             <input type="number" id="focusTimeout" min="0.5" max="60" step="0.5" />
             <div class="range-info">Range: 0.5 - 60 minutes</div>
         </div>

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -123,7 +123,7 @@ export class StatusBar implements vscode.Disposable {
 
         const notificationStatus = notificationsEnabled ? 'ON' : 'OFF';
         
-        return `${isActive ? 'Active' : 'Paused'} - Coding Time
+        return `${isActive ? 'Active' : 'Paused'} - Dev Pulse
 Project: ${currentProject}
 Branch: ${currentBranch}
 Current Project Today: ${formatTime(currentProjectTime)}

--- a/src/statusBar.ts.md
+++ b/src/statusBar.ts.md
@@ -1,6 +1,6 @@
 # `statusBar.ts` Documentation
 
-This file manages the VS Code status bar item for the Coding Time Tracker extension. It displays the current tracking status and provides quick access to extension commands.
+This file manages the VS Code status bar item for the Dev Pulse extension. It displays the current tracking status and provides quick access to extension commands.
 
 ## Overview
 - **Purpose:** Show time tracking status and provide user interaction via the status bar.

--- a/src/summaryView.ts
+++ b/src/summaryView.ts
@@ -89,7 +89,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
         } else {
             this.panel = vscode.window.createWebviewPanel(
                 'codingTimeSummary',
-                'Coding Time Summary',
+                'Dev Pulse Summary',
                 vscode.ViewColumn.One,
                 {
                     enableScripts: true,
@@ -161,7 +161,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
             <head>
                 <meta charset="UTF-8">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <title>Coding Time Summary</title>
+                <title>Dev Pulse Summary</title>
                 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
                 <style>
                     :root {
@@ -845,7 +845,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
             </head>
             <body>
                 <div class="header">
-                    <h1>Coding Time Summary</h1>
+                    <h1>Dev Pulse Summary</h1>
                     <button class="settings-button" id="open-settings-button">Settings</button>
                 </div>
                 <div class="container">
@@ -890,7 +890,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                         </div>
                     </div>
 
-                    <h2>Coding Time Analytics</h2>                  
+                    <h2>Dev Pulse Analytics</h2>
                     <div class="analytics-grid">
                         <div class="analytics-box">
                             <h3>Time Summary</h3>
@@ -927,7 +927,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                         </div>
                     </div>
 
-                    <h2>Coding Activity</h2>
+                    <h2>Dev Pulse Activity</h2>
                     <div class="heatmap-container">
                         <div class="heatmap-wrapper">
                             <div class="months-container"></div>
@@ -2203,7 +2203,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                             data: {
                                 labels: projectData.map(([key]) => key),
                                 datasets: [{
-                                    label: 'Coding Time',
+                                    label: 'Dev Pulse',
                                     data: projectData.map(([_, time]) => time/60),
                                     backgroundColor: chartColors.chartBlues,
                                     borderColor: chartColors.grid,
@@ -2243,7 +2243,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                                     return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
                                 }),
                                 datasets: [{
-                                    label: 'Coding Time',
+                                    label: 'Dev Pulse',
                                     data: dailyData.map(([_, time]) => time / 60),
                                     fill: true,
                                     backgroundColor: \`\${chartColors.accent}33\`,
@@ -2477,7 +2477,7 @@ export class SummaryViewProvider implements vscode.WebviewViewProvider {
                                     return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
                                 }),
                                 datasets: [{
-                                    label: 'Coding Time',
+                                    label: 'Dev Pulse',
                                     data: dailyChartData.map(([_, time]) => time / 60),
                                     fill: true,
                                     backgroundColor: \`\${chartColors.accent}33\`,

--- a/src/summaryView.ts.md
+++ b/src/summaryView.ts.md
@@ -1,6 +1,6 @@
 # `summaryView.ts` Documentation
 
-This file implements the summary view for the Coding Time Tracker extension. It provides a UI for users to review their tracked coding time, broken down by date, project, and branch.
+This file implements the summary view for the Dev Pulse extension. It provides a UI for users to review their tracked Dev Pulse, broken down by date, project, and branch.
 
 ## Overview
 - **Purpose:** Display aggregated time tracking data in a user-friendly format.
@@ -17,7 +17,7 @@ This file implements the summary view for the Coding Time Tracker extension. It 
   - Users can filter or refresh the data
 
 ## Usage
-- Invoked from extension commands or status bar actions to show the user's coding time summary.
+- Invoked from extension commands or status bar actions to show the user's Dev Pulse summary.
 
 ---
 

--- a/src/timeTracker.ts
+++ b/src/timeTracker.ts
@@ -22,8 +22,8 @@ export class TimeTracker implements vscode.Disposable {
     private updateInterval: NodeJS.Timeout | null = null;
     private saveInterval: NodeJS.Timeout | null = null;
     private saveIntervalSeconds: number = 5;
-    private lastCursorActivity: number = Date.now();
-    private cursorInactivityTimeout: NodeJS.Timeout | null = null;
+    // Deprecated: no longer used to auto-stop tracking (see updateConfiguration/package.json).
+    // Kept so existing user settings for this key don't error.
     private inactivityTimeoutSeconds: number = 150; // Default 2.5 minutes * 60 = 150 seconds
     private focusTimeoutHandle: NodeJS.Timeout | null = null;
     private focusTimeoutSeconds: number = 180; // Default 3 minutes * 60 = 180 seconds
@@ -90,7 +90,9 @@ export class TimeTracker implements vscode.Disposable {
             }
         }, '(', ',');
 
-        // Track when VS Code window gains focus
+        // Window focus is the sole authority for start/stop tracking (Dev Pulse
+        // model): any time the VS Code window has OS focus counts, whether the
+        // user is editing, chatting with AI, or running terminal commands.
         vscode.window.onDidChangeWindowState(async (e) => {
             const now = Date.now();
             if (e.focused) {
@@ -98,12 +100,17 @@ export class TimeTracker implements vscode.Disposable {
                     // Window regained focus within the timeout period
                     clearTimeout(this.focusTimeoutHandle);
                     this.focusTimeoutHandle = null;
-                    
+
                     // Save current session before starting new one
                     if (this.isTracking) {
                         await this.saveCurrentSession('window focus gained');
                     }
-                    this.startTracking('focus regained');
+                }
+                // Always (re)start on focus, not just when resuming from a pending
+                // grace timer — otherwise a window focused for the first time
+                // without ever having blurred first would never start tracking.
+                if (!this.isTracking) {
+                    await this.startTracking('focus regained');
                 }
                 this.lastFocusTime = now;
             } else {
@@ -174,35 +181,6 @@ export class TimeTracker implements vscode.Disposable {
         }
     }
 
-    private setupCursorTracking() {
-        if (this.cursorInactivityTimeout) {
-            clearTimeout(this.cursorInactivityTimeout);
-        }
-
-        const currentTime = Date.now();
-        const timeSinceLastActivity = currentTime - this.lastCursorActivity;
-
-        if (timeSinceLastActivity < this.inactivityTimeoutSeconds * 1000) {
-            this.cursorInactivityTimeout = setTimeout(() => {
-                const now = Date.now();
-                const inactivityDuration = now - this.lastCursorActivity;
-                
-                if (this.isTracking && inactivityDuration >= this.inactivityTimeoutSeconds * 1000) {
-                    this.logger.logEvent('inactivity_detected', {
-                        project: this.currentProject,
-                        branch: this.currentBranch,
-                        language: this.currentLanguage,
-                        inactivityDuration: inactivityDuration / 1000,
-                        lastActivityTime: new Date(this.lastCursorActivity).toISOString()
-                    });
-                    this.stopTracking('inactivity');
-                }
-            }, this.inactivityTimeoutSeconds * 1000);
-        }
-
-        this.lastCursorActivity = currentTime;
-    }
-
     public async updateCursorActivity() {
         // Don't auto-resume if user manually paused
         if (this.isPaused) {
@@ -224,9 +202,6 @@ export class TimeTracker implements vscode.Disposable {
             this.currentProject = currentProject;
             this.startTime = Date.now();
         }
-
-        this.lastCursorActivity = Date.now();
-        this.setupCursorTracking();
     }
 
     async startTracking(reason: string = 'manual') {
@@ -253,8 +228,7 @@ export class TimeTracker implements vscode.Disposable {
                 clearInterval(this.updateInterval);
             }
             this.updateInterval = setInterval(() => this.updateCurrentSession(), 1000);
-            
-            this.setupCursorTracking();
+
             await this.setupGitWatcher();
             
             // Start health notifications
@@ -273,11 +247,6 @@ export class TimeTracker implements vscode.Disposable {
                 this.updateInterval = null;
             }
             
-            if (this.cursorInactivityTimeout) {
-                clearTimeout(this.cursorInactivityTimeout);
-                this.cursorInactivityTimeout = null;
-            }
-
             this.logger.logEvent('tracking_stopped', {
                 reason: reason || 'manual',
                 project: this.currentProject,
@@ -320,7 +289,7 @@ export class TimeTracker implements vscode.Disposable {
         
         // Set up a simple way for user to resume - through a command or status bar click
         vscode.window.showInformationMessage(
-            'Coding timer paused. Click "Resume" to continue tracking.', 
+            'Dev Pulse paused. Click "Resume" to continue tracking.', 
             'Resume'
         ).then(selection => {
             if (selection === 'Resume') {
@@ -371,17 +340,38 @@ export class TimeTracker implements vscode.Disposable {
         }
     }
 
-    private validateTimeGap(): boolean {
+    // Ticks run every 1s; a gap far larger than that means the OS was
+    // suspended/locked (VS Code can stay "focused" through a sleep), so
+    // exclude the gap rather than silently banking it as Dev Pulse.
+    private static readonly SLEEP_GAP_THRESHOLD_MS = 30000;
+    private pendingSleepGapMinutes: number = 0;
+
+    private async validateTimeGap(): Promise<boolean> {
         const now = Date.now();
+        const gap = now - this.lastUpdateTime;
         this.lastUpdateTime = now;
+
+        if (this.isTracking && gap > TimeTracker.SLEEP_GAP_THRESHOLD_MS) {
+            this.logger.logEvent('sleep_gap_detected', {
+                project: this.currentProject,
+                branch: this.currentBranch,
+                language: this.currentLanguage,
+                gapSeconds: gap / 1000
+            });
+            this.pendingSleepGapMinutes = gap / 60000;
+            await this.saveCurrentSession('system sleep detected');
+            this.startTime = now;
+            return false;
+        }
+
         return true;
     }
 
     private updateCurrentSession() {
         // Validate time gap before updating session
-        if (!this.validateTimeGap()) {
-            return;
-        }
+        void this.validateTimeGap().catch((error) => {
+            console.error('Error validating time gap:', error);
+        });
         // This method will be called every second when tracking is active
         // You can emit an event here if you want to update the UI more frequently
     }
@@ -393,12 +383,13 @@ export class TimeTracker implements vscode.Disposable {
         let duration = (now - this.startTime) / 60000; // Convert to minutes
         
         // Adjust duration based on the reason for session end
-        if (reason === 'inactivity' && this.inactivityTimeoutSeconds) {
-            // Subtract the inactivity timeout period
-            duration = Math.max(0, duration - this.inactivityTimeoutSeconds / 60);
-        } else if (reason === 'focus timeout' && this.focusTimeoutSeconds) {
+        if (reason === 'focus timeout' && this.focusTimeoutSeconds) {
             // Subtract the focus timeout period
             duration = Math.max(0, duration - this.focusTimeoutSeconds / 60);
+        } else if (reason === 'system sleep detected' && this.pendingSleepGapMinutes) {
+            // Exclude the suspend/lock gap itself from the tracked duration
+            duration = Math.max(0, duration - this.pendingSleepGapMinutes);
+            this.pendingSleepGapMinutes = 0;
         }
 
         if (duration > 0) {
@@ -481,13 +472,10 @@ export class TimeTracker implements vscode.Disposable {
             .reduce((sum: number, entry: TimeEntry) => sum + entry.timeSpent, 0);
         
         if (this.isTracking) {
-            const timeSinceLastActivity = Date.now() - this.lastCursorActivity;
-            if (timeSinceLastActivity < this.inactivityTimeoutSeconds * 1000) {
-                const currentSessionTime = (Date.now() - this.startTime) / 60000;
-                return todayTotal + currentSessionTime;
-            }
+            const currentSessionTime = (Date.now() - this.startTime) / 60000;
+            return todayTotal + currentSessionTime;
         }
-        
+
         return todayTotal;
     }
 
@@ -505,13 +493,10 @@ export class TimeTracker implements vscode.Disposable {
             .reduce((sum: number, entry: TimeEntry) => sum + entry.timeSpent, 0);
         
         if (this.isTracking && this.currentProject === currentProject) {
-            const timeSinceLastActivity = Date.now() - this.lastCursorActivity;
-            if (timeSinceLastActivity < this.inactivityTimeoutSeconds * 1000) {
-                const currentSessionTime = (Date.now() - this.startTime) / 60000;
-                return currentProjectTime + currentSessionTime;
-            }
+            const currentSessionTime = (Date.now() - this.startTime) / 60000;
+            return currentProjectTime + currentSessionTime;
         }
-        
+
         return currentProjectTime;
     }
 
@@ -532,11 +517,8 @@ export class TimeTracker implements vscode.Disposable {
         const total = entries.reduce((sum: number, entry: TimeEntry) => sum + entry.timeSpent, 0);
 
         if (this.isTracking) {
-            const timeSinceLastActivity = Date.now() - this.lastCursorActivity;
-            if (timeSinceLastActivity < this.inactivityTimeoutSeconds * 1000) {
-                const currentSessionTime = (Date.now() - this.startTime) / 60000;
-                return total + currentSessionTime;
-            }
+            const currentSessionTime = (Date.now() - this.startTime) / 60000;
+            return total + currentSessionTime;
         }
 
         return total;
@@ -554,11 +536,8 @@ export class TimeTracker implements vscode.Disposable {
         const total = filteredEntries.reduce((sum, entry) => sum + entry.timeSpent, 0);
 
         if (this.isTracking) {
-            const timeSinceLastActivity = Date.now() - this.lastCursorActivity;
-            if (timeSinceLastActivity < this.inactivityTimeoutSeconds * 1000) {
-                const currentSessionTime = (Date.now() - this.startTime) / 60000;
-                return total + currentSessionTime;
-            }
+            const currentSessionTime = (Date.now() - this.startTime) / 60000;
+            return total + currentSessionTime;
         }
 
         return total;

--- a/src/timeTracker.ts.md
+++ b/src/timeTracker.ts.md
@@ -1,20 +1,22 @@
 # `timeTracker.ts` Documentation
 
-This file contains the core logic for tracking coding time in the Coding Time Tracker extension. It manages timers, detects activity, and records time entries.
+This file contains the core logic for tracking Dev Pulse (dev time) in the extension. It manages timers, detects window focus, and records time entries.
 
 ## Overview
-- **Purpose:** Track active coding time and record it to the database.
+- **Purpose:** Track time spent with the VS Code window focused and record it to the database.
 - **Main Responsibilities:**
   - Start and stop time tracking sessions
-  - Detect user activity and workspace/project/branch changes
+  - Detect window focus/blur and workspace/project/branch changes
   - Periodically save tracked time to the database
 
 ## Key Concepts
 - **Timer Management:**
   - Uses intervals or timeouts to track elapsed time
-  - Pauses/resumes based on user activity
-- **Activity Detection:**
-  - Monitors editor events to determine if the user is actively coding
+  - Pauses/resumes based on VS Code window focus, not editor keystrokes
+- **Focus-Based Tracking:**
+  - `onDidChangeWindowState` is the sole start/stop authority: tracking starts when the window gains focus and stops only after it has been unfocused longer than the configurable Focus Timeout
+  - Editor/cursor/hover events (`updateCursorActivity`) no longer stop tracking on inactivity — they're only used to detect a project switch and roll over the session
+  - A wall-clock gap check (`validateTimeGap`) excludes OS sleep/lock time from tracked sessions, since VS Code can stay reported as "focused" through a suspend
 - **Data Recording:**
   - Writes time entries to the database at regular intervals or on session end
 

--- a/src/utils.ts.md
+++ b/src/utils.ts.md
@@ -1,6 +1,6 @@
 # `utils.ts` Documentation
 
-This file provides utility functions for the Coding Time Tracker extension. These helpers support common operations used throughout the extension.
+This file provides utility functions for the Dev Pulse extension. These helpers support common operations used throughout the extension.
 
 ## Overview
 - **Purpose:** Encapsulate reusable logic and helper functions.


### PR DESCRIPTION
## Summary
This PR rebrand the extension to "Dev Pulse" and fundamentally changes the time tracking model from cursor/keystroke-based activity detection to window-focus-based tracking. The extension now counts any time the VS Code window is focused—coding, AI chat, terminal use—rather than only tracking editor keystrokes. Inactivity-based auto-stop is removed in favor of a single pause condition: the configurable Focus Timeout after the window loses focus.

## Key Changes

**Tracking Model Overhaul:**
- Removed cursor activity tracking (`lastCursorActivity`, `cursorInactivityTimeout`, `setupCursorTracking()` method)
- Window focus is now the sole authority for start/stop via `onDidChangeWindowState`
- Tracking starts immediately when VS Code gains focus and pauses only after the Focus Timeout expires with the window unfocused
- Removed all inactivity-based pause logic; `inactivityTimeoutSeconds` is now deprecated but retained for backward compatibility

**Sleep/Lock Detection:**
- Added `validateTimeGap()` to detect OS suspend/lock events (30+ second gaps between 1-second update ticks)
- Excludes sleep gaps from tracked time by saving the session and restarting the timer when a large gap is detected
- Logs `sleep_gap_detected` events for diagnostics

**Focus Timeout Handling:**
- Simplified focus regain logic: always restart tracking on focus if not already tracking, not just when resuming from a pending grace timer
- Ensures a window focused for the first time (without ever blurring) will start tracking

**UI & Branding:**
- Renamed "Simple Coding Time Tracker" → "Dev Pulse" throughout UI, settings, and documentation
- Updated all references: "Coding Time" → "Dev Pulse", "Coding Activity" → "Dev Pulse Activity"
- Updated settings descriptions to clarify focus-based model and deprecate inactivity timeout
- Disabled the inactivity timeout input in the settings UI

**Code Cleanup:**
- Removed redundant window state listeners from `extension.ts` (now handled entirely in `TimeTracker`)
- Removed document open listener that was redundant with focus-based tracking
- Simplified time calculation methods (`getTodayTotal`, `getProjectTime`, etc.) by removing inactivity checks
- Updated all documentation files to reflect the new focus-based model

**Version & Metadata:**
- Bumped version to 0.8.0
- Updated package.json keywords and descriptions
- Updated README with new feature descriptions emphasizing whole-window activity tracking

## Notable Implementation Details
- The `updateCursorActivity()` method is retained but now only detects project/branch changes; it no longer affects pause/resume logic
- Focus timeout is still configurable (default 3 minutes) and remains the only pause condition
- All existing user settings for inactivity timeout are preserved to avoid errors, but the setting is marked deprecated
- Sleep gap detection uses a 30-second threshold to distinguish OS suspend from normal pauses

https://claude.ai/code/session_019aaFxDtcDftu9TbABHnHxB